### PR TITLE
Remove dependency on ForgeRock JWT library

### DIFF
--- a/forgerock-authenticator/build.gradle
+++ b/forgerock-authenticator/build.gradle
@@ -153,13 +153,7 @@ install {
 }
 
 repositories {
-    maven {
-        credentials {
-            username "$forgerockUser"
-            password "$forgerockPassword"
-        }
-        url 'https://maven.forgerock.org/repo/releases/'
-    }
+    mavenCentral()
     google()
 }
 
@@ -171,31 +165,30 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     // JWT
-    implementation 'org.forgerock.commons:json-web-token:3.0.3'
+    implementation 'com.nimbusds:nimbus-jose-jwt:8.14'
 
     // Common
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.code.gson:gson:2.8.5'
 
     // FCM Notifications, make it optional for developer
-    compileOnly "com.google.firebase:firebase-messaging:20.1.5"
+    compileOnly "com.google.firebase:firebase-messaging:20.1.6"
 
     // Testing
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'androidx.test:runner:1.2.0'
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:2.27.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.3.1'
+    testImplementation 'org.robolectric:robolectric:4.3.1'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
     // JavaDoc ?
-    compileOnly "org.projectlombok:lombok:1.18.8"
     delombok "org.projectlombok:lombok:1.18.8"
     annotationProcessor 'org.projectlombok:lombok:1.18.8'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
-repositories {
-    mavenCentral()
-}
+

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/authenticator/PushFactory.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/authenticator/PushFactory.java
@@ -13,6 +13,7 @@ import androidx.annotation.VisibleForTesting;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
+import com.nimbusds.jose.JOSEException;
 
 import org.forgerock.android.auth.Logger;
 import org.forgerock.android.authenticator.exception.MechanismCreationException;
@@ -102,7 +103,7 @@ class PushFactory extends MechanismFactory {
                 throw new MechanismCreationException("Communication with server returned " +
                         returnCode + " code.");
             }
-        } catch (IOException | JSONException e) {
+        } catch (IOException | JSONException | JOSEException e) {
             throw new MechanismCreationException("Failed to register with server. " + e.getLocalizedMessage(), e);
         }
 
@@ -136,7 +137,7 @@ class PushFactory extends MechanismFactory {
 
     @VisibleForTesting
     int performPushRegistration(String registrationEndpoint, String amlbCookie, String base64Secret,
-                                    String messageId, Map<String, Object> payload) throws IOException, JSONException {
+                                    String messageId, Map<String, Object> payload) throws IOException, JSONException, JOSEException {
         return PushResponder.respond(registrationEndpoint, amlbCookie, base64Secret, messageId, payload);
     }
 

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/authenticator/PushParser.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/authenticator/PushParser.java
@@ -7,9 +7,9 @@
 
 package org.forgerock.android.authenticator;
 
+import android.util.Base64;
+
 import org.forgerock.android.authenticator.exception.MechanismParsingException;
-import org.forgerock.util.encode.Base64;
-import org.forgerock.util.encode.Base64url;
 
 import java.util.Map;
 
@@ -47,7 +47,7 @@ class PushParser extends MechanismParser {
         }
 
         if (containsNonEmpty(values, BASE_64_URL_IMAGE)) {
-            byte[] imageBytes = Base64url.decode(values.get(BASE_64_URL_IMAGE));
+            byte[] imageBytes = Base64.decode(values.get(BASE_64_URL_IMAGE), Base64.NO_WRAP);
             if (imageBytes != null) {
                 values.put(IMAGE, new String(imageBytes));
             }
@@ -71,7 +71,7 @@ class PushParser extends MechanismParser {
         if (!containsNonEmpty(data, key)) {
             throw new MechanismParsingException(key + " must not be empty");
         }
-        byte[] bytes = Base64url.decode(data.get(key));
+        byte[] bytes = Base64.decode(data.get(key), Base64.NO_WRAP);
 
         if (bytes == null) {
             throw new MechanismParsingException("Failed to decode value in " + key);
@@ -80,7 +80,7 @@ class PushParser extends MechanismParser {
     }
 
     String recodeBase64UrlValueToBase64WithValidation(Map<String, String> data, String key) throws MechanismParsingException{
-        return Base64.encode(decodeValueWithValidation(data, key));
+        return Base64.encodeToString(decodeValueWithValidation(data, key), Base64.NO_WRAP);
     }
 
     String recodeBase64UrlValueToStringWithValidation(Map<String, String> data, String key) throws MechanismParsingException{

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/authenticator/util/Base32String.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/authenticator/util/Base32String.java
@@ -1,4 +1,9 @@
 /*
+ * Copyright (c) 2020 ForgeRock. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ *
  * Portions Copyright 2009 Google Inc.
  */
 

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/authenticator/util/SortedList.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/authenticator/util/SortedList.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2020 ForgeRock. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package org.forgerock.android.authenticator.util;
 
 import java.util.ArrayList;

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/authenticator/util/TimeKeeper.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/authenticator/util/TimeKeeper.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2020 ForgeRock. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package org.forgerock.android.authenticator.util;
 
 import androidx.annotation.VisibleForTesting;

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/authenticator/AuthenticatorTestSuite.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/authenticator/AuthenticatorTestSuite.java
@@ -22,6 +22,7 @@ import org.junit.runners.Suite;
         OathFactoryTest.class,
         PushFactoryTest.class,
         PushParserTest.class,
+        PushResponderTest.class,
         PushTest.class,
         SortedListTest.class
 })

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/authenticator/PushFactoryTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/authenticator/PushFactoryTest.java
@@ -9,12 +9,16 @@ package org.forgerock.android.authenticator;
 
 import android.content.Context;
 
+import com.nimbusds.jose.JOSEException;
+
 import org.forgerock.android.auth.DefaultStorageClient;
 import org.forgerock.android.authenticator.exception.MechanismCreationException;
 import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import java.io.IOException;
 
@@ -28,6 +32,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
+@RunWith(RobolectricTestRunner.class)
 public class PushFactoryTest {
 
     private DefaultStorageClient storageClient;
@@ -35,7 +40,7 @@ public class PushFactoryTest {
     private Context context;
 
     @Before
-    public void setUp() throws IOException, JSONException {
+    public void setUp() throws IOException, JSONException, JOSEException {
         context = mock(Context.class);
 
         storageClient = mock(DefaultStorageClient.class);

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/authenticator/PushParserTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/authenticator/PushParserTest.java
@@ -10,12 +10,15 @@ package org.forgerock.android.authenticator;
 import org.forgerock.android.authenticator.exception.MechanismParsingException;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
+@RunWith(RobolectricTestRunner.class)
 public class PushParserTest {
 
     private PushParser pushParser;
@@ -58,7 +61,7 @@ public class PushParserTest {
     @Test
     public void testShouldParseSecret() throws MechanismParsingException {
         Map<String, String> result = pushParser.map("pushauth://push/forgerock:user?a=aHR0cDovL2Rldi5vcGVuYW0uZXhhbXBsZS5jb206ODA4MS9vcGVuYW0vanNvbi9kZXYvcHVzaC9zbnMvbWVzc2FnZT9fYWN0aW9uPWF1dGhlbnRpY2F0ZQ&b=519387&r=aHR0cDovL2Rldi5vcGVuYW0uZXhhbXBsZS5jb206ODA4MS9vcGVuYW0vanNvbi9kZXYvcHVzaC9zbnMvbWVzc2FnZT9fYWN0aW9uPXJlZ2lzdGVy&s=b3uYLkQ7dRPjBaIzV0t_aijoXRgMq-NP5AwVAvRfa_E&c=9giiBAdUHjqpo0XE4YdZ7pRlv0hrQYwDz8Z1wwLLbkg&l=YW1sYmNvb2tpZT0wMQ&m=REGISTER:8be951c6-af83-438d-8f74-421bd18650421570561063169&issuer=Rm9yZ2VSb2Nr");
-        assertEquals(result.get(PushParser.SHARED_SECRET), "b3uYLkQ7dRPjBaIzV0t/aijoXRgMq+NP5AwVAvRfa/E=");
+        assertEquals(result.get(PushParser.SHARED_SECRET), "b3uYLkQ7dRPjBaIzV0taijoXRgMqNP5AwVAvRfaE");
     }
 
     @Test

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/authenticator/PushResponderTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/authenticator/PushResponderTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2020 ForgeRock. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package org.forgerock.android.authenticator;
+
+import com.nimbusds.jose.JOSEException;
+
+import org.hamcrest.Matchers;
+import org.json.JSONException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+@RunWith(RobolectricTestRunner.class)
+public class PushResponderTest {
+    private MockWebServer server;
+
+    @Before
+    public void setUp() {
+        server = new MockWebServer();
+
+    }
+
+    @After
+    public void cleanUp() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    public void testShouldSendMessageCorrectly() throws Exception {
+        server.enqueue(new MockResponse());
+        server.start();
+
+        HttpUrl baseUrl = server.url("/");
+
+        int responseCode = PushResponder.respond(baseUrl.toString(), "testCookie", "b3uYLkQ7dRPjBaIzV0t/aijoXRgMq+NP5AwVAvRfa/E=",
+                "testMessageId", new HashMap<String, Object>());
+
+        RecordedRequest request = server.takeRequest();
+
+        assertEquals(responseCode, HTTP_OK);
+        assertEquals("resource=1.0, protocol=1.0", request.getHeader("Accept-API-Version"));
+        assertEquals("testCookie", request.getHeader("Cookie"));
+    }
+
+    @Test
+    public void testSendMessageFailure() throws Exception {
+        server.enqueue(new MockResponse().setResponseCode(HTTP_NOT_FOUND));
+        server.start();
+
+        HttpUrl baseUrl = server.url("/");
+
+        int responseCode = PushResponder.respond(baseUrl.toString(), "testCookie", "b3uYLkQ7dRPjBaIzV0t/aijoXRgMq+NP5AwVAvRfa/E=",
+                "testMessageId", new HashMap<String, Object>());
+
+        RecordedRequest request = server.takeRequest();
+
+        assertEquals(responseCode, HTTP_NOT_FOUND);
+        assertEquals("resource=1.0, protocol=1.0", request.getHeader("Accept-API-Version"));
+        assertEquals("testCookie", request.getHeader("Cookie"));
+    }
+
+    @Test
+    public void testShouldRejectEmptySecret() {
+
+        try {
+            PushResponder.respond("http://example.com", "testCookie", "",
+                    "testMessageId", new HashMap<String, Object>());
+        } catch (IOException | JSONException | JOSEException e) {
+            assertEquals(e.getClass(), IOException.class);
+            assertEquals(e.getLocalizedMessage(), "Passed empty secret");
+        }
+    }
+
+    @Test
+    public void testShouldRejectInvalidSecret() {
+
+        try {
+            PushResponder.respond("http://example.com", "testCookie", "dGVzdHNlY3JldA==",
+                    "testMessageId", new HashMap<String, Object>());
+        } catch (IOException | JSONException | JOSEException e) {
+            assertEquals(e.getClass(), IOException.class);
+            assertEquals(e.getLocalizedMessage(), "Invalid secret!");
+        }
+    }
+
+    @Test
+    public void testShouldGenerateChallengeResponseCorrectly() {
+        String base64Secret = "b3uYLkQ7dRPjBaIzV0t/aijoXRgMq+NP5AwVAvRfa/E=";
+        String base64Challenge = "9giiBAdUHjqpo0XE4YdZ7pRlv0hrQYwDz8Z1wwLLbkg=";
+
+        String response = PushResponder.generateChallengeResponse(base64Secret, base64Challenge);
+
+        assertEquals(response, "Df02AwA3Ra+sTGkL5+QvkEtN3eLdZiFmL5nxAV1m0k8=");
+    }
+
+    @Test
+    public void testShouldSignJWTCorrectly() throws Exception {
+        server.enqueue(new MockResponse());
+        server.start();
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("deviceId", "testFcmToken");
+        payload.put("deviceType", "android");
+        payload.put("communicationType", "gcm");
+        payload.put("mechanismUid", "testMechanismUid");
+        payload.put("response", "Df02AwA3Ra+sTGkL5+QvkEtN3eLdZiFmL5nxAV1m0k8=");
+
+        HttpUrl baseUrl = server.url("/");
+
+        int responseCode = PushResponder.respond(baseUrl.toString(), "testCookie", "b3uYLkQ7dRPjBaIzV0t/aijoXRgMq+NP5AwVAvRfa/E=",
+                "testMessageId", payload);
+
+        RecordedRequest request = server.takeRequest();
+
+        String body = request.getBody().readUtf8();
+
+        assertEquals(responseCode, HTTP_OK);
+        assertEquals("resource=1.0, protocol=1.0", request.getHeader("Accept-API-Version"));
+        assertEquals("testCookie", request.getHeader("Cookie"));
+        assertThat(body, Matchers.containsString("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJkZXZpY2VUeXBlIjoiYW5kcm9pZCIsIm1lY2hhbmlzbVVpZCI6InRlc3RNZWNoYW5pc21VaWQiLCJyZXNwb25zZSI6IkRmMDJBd0EzUmErc1RHa0w1K1F2a0V0TjNlTGRaaUZtTDVueEFWMW0wazg9IiwiY29tbXVuaWNhdGlvblR5cGUiOiJnY20iLCJkZXZpY2VJZCI6InRlc3RGY21Ub2tlbiJ9.UimglbtcwK6vD0mYZW_B3Yge6chPR--5mPmyHB0maas"));
+    }
+
+}


### PR DESCRIPTION
This PR includes the implementation for the following story:

SDKS-355 [Android][Authenticator SDK] Remove dependency on ForgeRock JWT library

Notes:
- The latest version of the Nimbus JWT library was used
- The change of library also required to re-write other parts of the code, once it was also using the Base64 class included in ForgeRock package.
- Some unit tests also required changes, because the "android.util.Base64" class used to replace the previous one, can't be used in a regular JUnit test, so now for those tests we are using Robolectric Runner, which is also used in "forgerock-auth" module
- Included unit tests for PushResponder class
