### PR TITLE
Fix broken link to CHANGELOG.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   </a>
   <h2 align="center">ForgeRock SDK for Android</h2>
   <p align="center">
-    <a href="./blob/master/CHANGELOG.md">Change Log</a>
+    <a href="CHANGELOG.md">Change Log</a>
     ·
     <a href="#support">Support</a>
     ·


### PR DESCRIPTION
Now links relative to the repository and correctly to the Change Log. The old revision 404s.

The old revision currently points to https://github.com/ForgeRock/forgerock-android-sdk/blob/master/blob/master/CHANGELOG.md. Note the extra `blob/master/` that leads to a page that doesn't exist.
