### PR TITLE
SDKS-612 Should not remove Account which is not created by the SDK

### DIFF
--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/DefaultSingleSignOnManager.java
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/DefaultSingleSignOnManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 - 2020 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -44,10 +44,15 @@ class DefaultSingleSignOnManager implements SingleSignOnManager, ResponseHandler
     private static final Action LOGOUT = new Action(Action.LOGOUT);
 
     @Builder
-    private DefaultSingleSignOnManager(@NonNull Context context, ServerConfig serverConfig, Encryptor encryptor, SharedPreferences sharedPreferences) {
+    private DefaultSingleSignOnManager(@NonNull Context context,
+                                       ServerConfig serverConfig,
+                                       String accountName,
+                                       Encryptor encryptor,
+                                       SharedPreferences sharedPreferences) {
         try {
             singleSignOnManager = AccountSingleSignOnManager.builder()
                     .context(context)
+                    .accountName(accountName == null ? context.getString(R.string.forgerock_account_name) : accountName)
                     .encryptor(encryptor).build();
         } catch (Exception e) {
             Logger.warn(TAG, "Fallback to SharedPreference to store SSO Token");

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/OAuth2Client.java
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/OAuth2Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 - 2020 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -62,7 +62,6 @@ public class OAuth2Client {
         this.scope = scope;
         this.redirectUri = redirectUri;
         this.serverConfig = serverConfig;
-        this.okHttpClient = OkHttpClientProvider.getInstance().lookup(serverConfig);
     }
 
     /**
@@ -90,7 +89,7 @@ public class OAuth2Client {
                     .tag(AUTHORIZE)
                     .build();
 
-            okHttpClient.newCall(request).enqueue(new okhttp3.Callback() {
+            getOkHttpClient().newCall(request).enqueue(new okhttp3.Callback() {
 
                 @Override
                 public void onFailure(@NotNull Call call, @NotNull IOException e) {
@@ -145,7 +144,7 @@ public class OAuth2Client {
                     .build();
 
 
-            okHttpClient.newCall(request).enqueue(new okhttp3.Callback() {
+            getOkHttpClient().newCall(request).enqueue(new okhttp3.Callback() {
 
                 @Override
                 public void onFailure(@NotNull Call call, @NotNull IOException e) {
@@ -185,7 +184,7 @@ public class OAuth2Client {
                     .build();
 
 
-            okHttpClient.newCall(request).enqueue(new okhttp3.Callback() {
+            getOkHttpClient().newCall(request).enqueue(new okhttp3.Callback() {
 
                 @Override
                 public void onFailure(@NotNull Call call, @NotNull IOException e) {
@@ -201,6 +200,13 @@ public class OAuth2Client {
         } catch (IOException e) {
             Listener.onException(listener, e);
         }
+    }
+
+    private OkHttpClient getOkHttpClient() {
+        if (okHttpClient == null) {
+            okHttpClient = OkHttpClientProvider.getInstance().lookup(serverConfig);
+        }
+        return okHttpClient;
     }
 
     /**
@@ -232,7 +238,7 @@ public class OAuth2Client {
                     .tag(EXCHANGE_TOKEN)
                     .build();
 
-            okHttpClient.newCall(request).enqueue(new Callback() {
+            getOkHttpClient().newCall(request).enqueue(new Callback() {
                 @Override
                 public void onFailure(@NotNull Call call, @NotNull IOException e) {
                     listener.onException(e);
@@ -313,4 +319,5 @@ public class OAuth2Client {
             return new PKCE("plain", codeVerifier, codeVerifier);
         }
     }
+
 }

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/SessionManager.java
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/SessionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 - 2020 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -7,6 +7,7 @@
 
 package org.forgerock.android.auth;
 
+import androidx.annotation.VisibleForTesting;
 import androidx.annotation.WorkerThread;
 
 import lombok.Builder;
@@ -78,6 +79,25 @@ class SessionManager {
     void close() {
         tokenManager.revoke(null);
         singleSignOnManager.revoke(null);
+    }
+
+    @VisibleForTesting
+    void close(FRListener<Void> listener) {
+        tokenManager.revoke(new FRListener<Void>() {
+            @Override
+            public void onSuccess(Void result) {
+                closeSession(listener);
+           }
+
+            @Override
+            public void onException(Exception e) {
+                closeSession(listener);
+            }
+        });
+    }
+
+    private void closeSession(FRListener<Void> listener) {
+        singleSignOnManager.revoke(listener);
     }
 
 }


### PR DESCRIPTION
When using Android Account manager for SSO, an Account type org.forgerock and Account ForgeRock is created, since only one Account type can be created for an App, the developer may want to create Account for their own App, currently, during user logout with the SDK, the SDK removes all Account under org.forgerock, it should just remove the account created by the SDK.

Few minor enhancement for the PR:

1. Do not remove Account which is not created by SDK
2. Account Name can be provided as a parameter instead of hardcode in the file. (Internal Interface change)
3. Lazy initializing the HttpClient for OAuth2Client
