### PR TITLE
Fixed gradle build from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/ForgeRock/forgerock-android-sdk?color=%23f46200&label=Version&style=flat-square)](CHANGELOG.md)
+[![Build Status](https://jenkins.petrov.ca/buildStatus/icon?job=Android-SDK&style=flat-square)](https://jenkins.petrov.ca/job/Android-SDK/)
 
 <p align="center">
   <a href="https://github.com/ForgeRock">

--- a/forgerock-auth/build.gradle
+++ b/forgerock-auth/build.gradle
@@ -32,11 +32,14 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            manifestPlaceholders = [
+                    'appAuthRedirectScheme': 'org.forgerock.demo'
+            ]
         }
 
         debug {
             manifestPlaceholders = [
-                    'appAuthRedirectScheme': 'org.forgerock.test'
+                    'appAuthRedirectScheme': 'org.forgerock.demo'
             ]
         }
     }


### PR DESCRIPTION
- Fixed build build.gradle in forgerock-auth which was causing build failure from command line.
- Embedded build status label in README.md
- Fixed the 'testShouldSignJWTCorrectly' test to be more reliable (it was failing randomly)