### PR TITLE
Updated the userinfo assertion in FRUserTest to check user's email

### DIFF
--- a/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/AndroidBaseTest.java
+++ b/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/AndroidBaseTest.java
@@ -18,6 +18,7 @@ public abstract class AndroidBaseTest {
     protected Context context = ApplicationProvider.getApplicationContext();
     public static String USERNAME = "sdkuser";
     public static String PASSWORD = "password";
+    public static String USER_EMAIL = "sdkuser@example.com";
 
     protected String TREE = "UsernamePassword";
 

--- a/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/FRUserTest.java
+++ b/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/FRUserTest.java
@@ -73,8 +73,7 @@ public class FRUserTest extends AndroidBaseTest {
         FRListenerFuture<UserInfo> future = new FRListenerFuture<>();
         FRUser.getCurrentUser().getUserInfo(future);
         UserInfo userinfo = future.get();
-        assertEquals(USERNAME, userinfo.getSub());
-
+        assertEquals(USER_EMAIL, userinfo.getEmail());
     }
 
     @Test


### PR DESCRIPTION
Updated the userinfo assertion in FRUserTest to check user's email, instead of username, since the "sub" attribute in most cases is a dynamic UID. 