### PR TITLE
ACCESS_BACKGROUND_LOCATION permission added to Auth test app Manifest

### DIFF
--- a/forgerock-auth/src/androidTest/AndroidManifest.xml
+++ b/forgerock-auth/src/androidTest/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 
     <application
             android:label="@string/app_name"


### PR DESCRIPTION
ACCESS_BACKGROUND_LOCATION permission is needed in order a couple tests to pass when running on real device (e.g: BitBar)