### PR TITLE
Updated the public key pins for api.ipify.org

### DIFF
--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/ServerConfigTest.java
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/ServerConfigTest.java
@@ -76,7 +76,7 @@ public class ServerConfigTest {
         ServerConfig serverConfig = ServerConfig.builder()
                 .context(context)
                 .url("https://api.ipify.org")
-                .pin("sha256/gAZLWmiY0ORGxqG0ccEhqiB3baugOOs9vdcezRCHc44=")
+                .pin("sha256/9hNxmEFgLKGJXqgp61hyb8yIyiT9u0vgDZh4y8TmY/M=")
                 .build();
 
         OkHttpClient client = OkHttpClientProvider.getInstance().lookup(serverConfig);
@@ -115,7 +115,7 @@ public class ServerConfigTest {
         ServerConfig serverConfig = ServerConfig.builder()
                 .context(context)
                 .url("https://api.ipify.org")
-                .pin("sha1/jgXAj7NCdI7mOsNIRIghvGKLgVA=")
+                .pin("sha1/2vB3hhEJ98C5efhhWpxtD2wxYek=")
                 .build();
 
         OkHttpClient client = OkHttpClientProvider.getInstance().lookup(serverConfig);
@@ -157,7 +157,7 @@ public class ServerConfigTest {
         ServerConfig serverConfig = ServerConfig.builder()
                 .context(context)
                 .url("https://api.ipify.org")
-                .pin("sha256/gAZLWmiY0ORGxqG0ccEhqiB3baugOOs9vdcezRCHc44=")
+                .pin("sha256/9hNxmEFgLKGJXqgp61hyb8yIyiT9u0vgDZh4y8TmY/M=")
                 .pin("sha256/invalid")
                 .build();
 

--- a/samples/auth/src/main/java/org/forgerock/auth/MainActivity.java
+++ b/samples/auth/src/main/java/org/forgerock/auth/MainActivity.java
@@ -277,7 +277,9 @@ public class MainActivity extends AppCompatActivity {
                     });
 
                     if (FRSession.getCurrentSession() != null) {
-                        put(output, "SESSION", FRSession.getCurrentSession().getSessionToken().getValue());
+                        if (FRSession.getCurrentSession().getSessionToken() != null) {
+                            put(output, "SESSION", FRSession.getCurrentSession().getSessionToken().getValue());
+                        }
                     }
                 }
 


### PR DESCRIPTION
* Updated the public key pins for api.ipify.org - certificate has been updated, which causes test failure of the "ServerConfig" tests. 
* Added check for null for session token to avoid sample app crash upon invoking the "view tokens" option in "centralized login" scenario.