### PR TITLE
Exposing Revoke Access Token method to FRUser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 #### Added
 - Social Login support for Google and Facebook
 - Biometric Authentication with WebAuthn
+- Exposed Revoke access token method [SDKS-980] - 'FRUser.getCurrentUser().revokeAccessToken(Listener)'
+
 
 # Version 2.2.0
 

--- a/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/FRUserTest.java
+++ b/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/FRUserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/FRUser.java
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/FRUser.java
@@ -79,6 +79,15 @@ public class FRUser {
         sessionManager.close();
     }
 
+    /**
+     * Revoke the {@link AccessToken} asynchronously,
+     *
+     *
+     * @param listener Listener to listen for token revocation event.
+     */
+    public void revokeAccessToken(FRListener<Void> listener) {
+        sessionManager.revokeAccessToken(listener);
+    }
 
     /**
      * Retrieve the {@link AccessToken} asynchronously,

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/SessionManager.java
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/SessionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -97,6 +97,11 @@ class SessionManager {
         singleSignOnManager.revoke(null);
     }
 
+    /**
+     * Calling TokenManager to revoke OAuth2.0 tokens
+     *
+     * @param listener The Listener to listen for the result
+     */
     void revokeAccessToken(FRListener<Void> listener) {
         tokenManager.revoke(listener);
     }

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/SessionManager.java
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/SessionManager.java
@@ -97,6 +97,10 @@ class SessionManager {
         singleSignOnManager.revoke(null);
     }
 
+    void revokeAccessToken(FRListener<Void> listener) {
+        tokenManager.revoke(listener);
+    }
+
     @VisibleForTesting
     void close(FRListener<Void> listener) {
         tokenManager.revoke(new FRListener<Void>() {

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/TokenManager.java
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/TokenManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/FRUserMockTest.java
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/FRUserMockTest.java
@@ -208,6 +208,36 @@ public class FRUserMockTest extends BaseTest {
     }
 
     @Test
+    public void testRevokeAccessToken() throws Exception {
+        frUserHappyPath();
+        
+        //Revoke the token and check the listener onSuccess and onFailure methods
+        FRUser.getCurrentUser().revokeAccessToken(new FRListener<Void>() {
+            @Override
+            public void onSuccess(Void result) {
+                assertNotNull(FRUser.getCurrentUser());
+                assertTokenRevoked();
+            }
+
+            @Override
+            public void onException(Exception e) {
+                assertNotNull(FRUser.getCurrentUser());
+                assertTokenRevoked();
+            }
+        });
+    }
+
+    private void assertTokenRevoked() {
+        try {
+            AccessToken accessToken = FRUser.getCurrentUser().getAccessToken();
+            assertNull(accessToken.getValue());
+        }catch(AuthenticationRequiredException cEx) {
+            fail(cEx.getMessage());
+        }
+    }
+
+
+    @Test
     public void testAccessTokenAsync() throws Exception {
         frUserHappyPath();
         FRListenerFuture<AccessToken> future = new FRListenerFuture<>();

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/FRUserMockTest.java
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/FRUserMockTest.java
@@ -217,6 +217,12 @@ public class FRUserMockTest extends BaseTest {
         assertTrue(Config.getInstance().getTokenManager().hasToken());
         //Revoke the token
         FRUser.getCurrentUser().revokeAccessToken(future);
+        try {
+            future.get();
+        } catch (ExecutionException e) {
+            //Timeout exception expected
+            assertEquals("java.net.SocketTimeoutException: timeout", e.getMessage());
+        }
         //Check that the token has been cleared
         assertFalse(Config.getInstance().getTokenManager().hasToken());
     }

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/FRUserMockTest.java
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/FRUserMockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/FRUserMockTest.java
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/FRUserMockTest.java
@@ -210,32 +210,16 @@ public class FRUserMockTest extends BaseTest {
     @Test
     public void testRevokeAccessToken() throws Exception {
         frUserHappyPath();
-        
-        //Revoke the token and check the listener onSuccess and onFailure methods
-        FRUser.getCurrentUser().revokeAccessToken(new FRListener<Void>() {
-            @Override
-            public void onSuccess(Void result) {
-                assertNotNull(FRUser.getCurrentUser());
-                assertTokenRevoked();
-            }
 
-            @Override
-            public void onException(Exception e) {
-                assertNotNull(FRUser.getCurrentUser());
-                assertTokenRevoked();
-            }
-        });
+        FRListenerFuture<Void> future = new FRListenerFuture<>();
+        assertNotNull(FRUser.getCurrentUser());
+        //Check if the token exists
+        assertTrue(Config.getInstance().getTokenManager().hasToken());
+        //Revoke the token
+        FRUser.getCurrentUser().revokeAccessToken(future);
+        //Check that the token has been cleared
+        assertFalse(Config.getInstance().getTokenManager().hasToken());
     }
-
-    private void assertTokenRevoked() {
-        try {
-            AccessToken accessToken = FRUser.getCurrentUser().getAccessToken();
-            assertNull(accessToken.getValue());
-        }catch(AuthenticationRequiredException cEx) {
-            fail(cEx.getMessage());
-        }
-    }
-
 
     @Test
     public void testAccessTokenAsync() throws Exception {

--- a/samples/auth/src/main/java/org/forgerock/auth/MainActivity.java
+++ b/samples/auth/src/main/java/org/forgerock/auth/MainActivity.java
@@ -282,7 +282,10 @@ public class MainActivity extends AppCompatActivity {
                     }
                 }
 
-
+            case R.id.revokeToken:
+                progressBar.setVisibility(VISIBLE);
+                revokeAccessToken();
+                return true;
             default:
                 return super.onOptionsItemSelected(item);
         }
@@ -320,6 +323,30 @@ public class MainActivity extends AppCompatActivity {
                 }
             });
         } else {
+            content.setText("No User Session");
+        }
+    }
+
+    private void revokeAccessToken() {
+        if (FRUser.getCurrentUser() != null) {
+            FRUser.getCurrentUser().revokeAccessToken(new FRListener<Void>() {
+                @Override
+                public void onSuccess(Void result) {
+                    progressBar.setVisibility(INVISIBLE);
+                    content.setText("Access token revoked");
+                    content.setText(result.toString());
+                }
+
+                @Override
+                public void onException(Exception e) {
+                    runOnUiThread(() -> {
+                        progressBar.setVisibility(INVISIBLE);
+                        content.setText(e.getMessage());
+                    });
+                }
+            });
+        } else {
+            progressBar.setVisibility(INVISIBLE);
             content.setText("No User Session");
         }
     }

--- a/samples/auth/src/main/java/org/forgerock/auth/MainActivity.java
+++ b/samples/auth/src/main/java/org/forgerock/auth/MainActivity.java
@@ -343,8 +343,8 @@ public class MainActivity extends AppCompatActivity {
                 public void onException(Exception e) {
                     runOnUiThread(() -> {
                         progressBar.setVisibility(INVISIBLE);
-                        content.setText("Access token revoked locally");
-                        content.setText(e.getMessage());
+                        content.setText("Access token revoked locally only!\n");
+                        content.append("Error message: " + e.getMessage());
                     });
                 }
             });

--- a/samples/auth/src/main/java/org/forgerock/auth/MainActivity.java
+++ b/samples/auth/src/main/java/org/forgerock/auth/MainActivity.java
@@ -281,6 +281,7 @@ public class MainActivity extends AppCompatActivity {
                         }
                     }
                 }
+                return true;
 
             case R.id.revokeToken:
                 progressBar.setVisibility(VISIBLE);
@@ -332,15 +333,17 @@ public class MainActivity extends AppCompatActivity {
             FRUser.getCurrentUser().revokeAccessToken(new FRListener<Void>() {
                 @Override
                 public void onSuccess(Void result) {
-                    progressBar.setVisibility(INVISIBLE);
-                    content.setText("Access token revoked");
-                    content.setText(result.toString());
+                    runOnUiThread(() -> {
+                        progressBar.setVisibility(INVISIBLE);
+                        content.setText("Access token revoked");
+                    });
                 }
 
                 @Override
                 public void onException(Exception e) {
                     runOnUiThread(() -> {
                         progressBar.setVisibility(INVISIBLE);
+                        content.setText("Access token revoked locally");
                         content.setText(e.getMessage());
                     });
                 }

--- a/samples/auth/src/main/res/menu/menu.xml
+++ b/samples/auth/src/main/res/menu/menu.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2019 - 2020 ForgeRock. All rights reserved.
+  ~ Copyright (c) 2019 - 2021 ForgeRock. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/auth/src/main/res/menu/menu.xml
+++ b/samples/auth/src/main/res/menu/menu.xml
@@ -43,5 +43,10 @@
         android:title="@string/token"
         app:showAsAction="collapseActionView"/>
 
+    <item android:id="@+id/revokeToken"
+        android:icon="@android:drawable/ic_menu_crop"
+        android:title="@string/revokeToken"
+        app:showAsAction="collapseActionView"/>
+
 
 </menu>

--- a/samples/auth/src/main/res/values/strings.xml
+++ b/samples/auth/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="token">Show Tokens</string>
     <string name="register">Register</string>
     <string name="authenticate">Authenticate</string>
+    <string name="revokeToken">Revoke Token</string>
 
     <!--  ForgeRock SDK Configuration -->
 


### PR DESCRIPTION
Expose revoke method in FRUser
Developers will need to call Revoke and then GetAccessToken to ForceRefresh the AccessToken
Added revocation example in the Sample App