### PR TITLE
SDKS-1006 Expose API to get all push notifications stored

### DIFF
--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/AuthenticatorManager.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/AuthenticatorManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -214,6 +214,10 @@ class AuthenticatorManager {
             throw new InvalidNotificationException("Cannot process Push notification. " +
                     "FCM token was not provided during SDK initialization.");
         }
+    }
+
+    List<PushNotification> getAllNotifications() {
+        return storageClient.getAllNotifications();
     }
 
     List<PushNotification> getAllNotifications(@NonNull Mechanism mechanism) {

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/DefaultStorageClient.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/DefaultStorageClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -151,12 +151,8 @@ class DefaultStorageClient implements StorageClient {
                 .commit();
     }
 
-    /**
-     * Get all notifications stored in the system.
-     *
-     * @return The complete list of notifications.
-     */
-    private List<PushNotification> getAllNotifications() {
+    @Override
+    public List<PushNotification> getAllNotifications() {
         List<PushNotification> pushNotificationList = new ArrayList<>();
 
         Map<String,?> keys = notificationData.getAll();

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/FRAClient.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/FRAClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -187,6 +187,15 @@ public class FRAClient {
      */
     public boolean removeMechanism(@NonNull Mechanism mechanism) {
         return this.authenticatorManager.removeMechanism(mechanism);
+    }
+
+    /**
+     * Get single list of notifications across all mechanisms.
+     * Returns {@code null} if no {@link PushNotification} could be found.
+     * @return The complete list of notifications
+     */
+    public List<PushNotification> getAllNotifications() {
+        return this.authenticatorManager.getAllNotifications();
     }
 
     /**

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/StorageClient.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/StorageClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -71,6 +71,12 @@ public interface StorageClient {
      * @return boolean as result of the operation
      */
     boolean setMechanism(Mechanism mechanism);
+
+    /**
+     * Get all notifications from the storage system.
+     * @return The complete list of notifications.
+     */
+    List<PushNotification> getAllNotifications();
 
     /**
      * Get all notifications for within the mechanism.

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/CustomStorageClient.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/CustomStorageClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -67,6 +67,11 @@ public class CustomStorageClient implements StorageClient {
     @Override
     public boolean setMechanism(Mechanism mechanism) {
         return false;
+    }
+
+    @Override
+    public List<PushNotification> getAllNotifications() {
+        return null;
     }
 
     @Override

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/FRAClientTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/FRAClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -539,6 +539,37 @@ public class FRAClientTest extends FRABaseTest {
 
         assertNotNull(mechanismFromStorage);
         assertEquals(push, mechanismFromStorage);
+    }
+
+    @Test
+    public void testShouldGetAllNotifications() throws Exception {
+        FRAClient fraClient = FRAClient.builder()
+                .withContext(context)
+                .withDeviceToken("s-o-m-e-t-o-k-e-n")
+                .withStorage(storageClient)
+                .start();
+
+        assertNotNull(fraClient);
+        assertNotNull(fraClient.getAuthenticatorManagerInstance());
+
+        Account account = createAccount(ACCOUNT_NAME, ISSUER);
+        Mechanism push = createPushMechanism(ACCOUNT_NAME, ISSUER, MECHANISM_UID);
+
+        List<Mechanism> mechanismList= new ArrayList<>();
+        mechanismList.add(push);
+
+        List<PushNotification> notificationList = new ArrayList<>();
+        notificationList.add(createPushNotification(MESSAGE_ID, push));
+        notificationList.add(createPushNotification(OTHER_MESSAGE_ID, push));
+
+        given(storageClient.getAccount(any(String.class))).willReturn(account);
+        given(storageClient.getMechanismsForAccount(any(Account.class))).willReturn(mechanismList);
+        given(storageClient.getAllNotifications()).willReturn(notificationList);
+
+        List<PushNotification> notificationListFromStorage = fraClient.getAllNotifications();
+
+        assertNotNull(notificationListFromStorage);
+        assertEquals(notificationList.size(), notificationListFromStorage.size());
     }
 
     @Test


### PR DESCRIPTION
On this change a new `getAllNotifications()` method is exposed on the FRAClient class. This will allow developers to retrieve a single list of notifications across all mechanisms.
