### PR TITLE
SDKS 1187

### DIFF
--- a/forgerock-authenticator/src/androidTest/java/org/forgerock/android/auth/MockModelBuilder.java
+++ b/forgerock-authenticator/src/androidTest/java/org/forgerock/android/auth/MockModelBuilder.java
@@ -7,6 +7,9 @@
 
 package org.forgerock.android.auth;
 
+import org.forgerock.android.auth.exception.InvalidNotificationException;
+import org.forgerock.android.auth.exception.MechanismCreationException;
+
 import java.util.Calendar;
 
 /**
@@ -36,7 +39,7 @@ public class MockModelBuilder {
     }
 
     public static OathMechanism createOath(String mechanismUID, String issuer, String accountName, OathMechanism.TokenType oathType,
-                                           String algorithm, String secret, int digits, long counter, int period) {
+                                           String algorithm, String secret, int digits, long counter, int period) throws MechanismCreationException {
 
         switch (oathType) {
             case TOTP:
@@ -65,7 +68,7 @@ public class MockModelBuilder {
     }
 
     public static PushMechanism createPush(String mechanismUID, String issuer, String accountName, String secret,
-                                           String registrationEndpoint, String authenticationEndpoint) {
+                                           String registrationEndpoint, String authenticationEndpoint) throws MechanismCreationException {
         PushMechanism push = PushMechanism.builder()
                 .setMechanismUID(mechanismUID)
                 .setIssuer(issuer)
@@ -82,7 +85,7 @@ public class MockModelBuilder {
                                                       String challenge, String amlbCookie,
                                                       Calendar timeAdded, Calendar timeExpired,
                                                       long ttl, boolean approved,
-                                                      boolean pending) {
+                                                      boolean pending) throws InvalidNotificationException {
 
         PushNotification pushNotification = PushNotification.builder()
                 .setMechanismUID(mechanismUID)
@@ -101,7 +104,7 @@ public class MockModelBuilder {
 
     public static PushNotification createNotification(String mechanismUID, String messageId,
                                                       String challenge, String amlbCookie,
-                                                      Calendar timeAdded, long ttl) {
+                                                      Calendar timeAdded, long ttl) throws InvalidNotificationException {
 
         PushNotification pushNotification = PushNotification.builder()
                 .setMechanismUID(mechanismUID)

--- a/forgerock-authenticator/src/androidTest/java/org/forgerock/android/auth/SecuredStorageTest.java
+++ b/forgerock-authenticator/src/androidTest/java/org/forgerock/android/auth/SecuredStorageTest.java
@@ -12,6 +12,8 @@ import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import org.forgerock.android.auth.exception.InvalidNotificationException;
+import org.forgerock.android.auth.exception.MechanismCreationException;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -160,7 +162,7 @@ public class SecuredStorageTest {
     }
 
     @Test
-    public void testStoreOathMechanism() {
+    public void testStoreOathMechanism() throws MechanismCreationException {
         DefaultStorageClient defaultStorage = new DefaultStorageClient(context);
 
         Account account = MockModelBuilder.createAccount(ISSUER, ACCOUNT_NAME);
@@ -180,7 +182,7 @@ public class SecuredStorageTest {
     }
 
     @Test
-    public void testStorePushMechanism() {
+    public void testStorePushMechanism() throws MechanismCreationException {
         DefaultStorageClient defaultStorage = new DefaultStorageClient(context);
 
         Account account = MockModelBuilder.createAccount(ISSUER, ACCOUNT_NAME);
@@ -200,7 +202,7 @@ public class SecuredStorageTest {
     }
 
     @Test
-    public void testStoreMultipleMechanismsForSameAccount() {
+    public void testStoreMultipleMechanismsForSameAccount() throws MechanismCreationException {
         DefaultStorageClient defaultStorage = new DefaultStorageClient(context);
         Account account = MockModelBuilder.createAccount(ISSUER, ACCOUNT_NAME);
         Mechanism mechanism1 = MockModelBuilder.createPush(MECHANISM_UID, ISSUER, ACCOUNT_NAME, SECRET,
@@ -222,7 +224,7 @@ public class SecuredStorageTest {
     }
 
     @Test
-    public void testUpdateExistingMechanism() {
+    public void testUpdateExistingMechanism() throws MechanismCreationException {
         DefaultStorageClient defaultStorage = new DefaultStorageClient(context);
 
         Account account = MockModelBuilder.createAccount(ISSUER, ACCOUNT_NAME);
@@ -254,7 +256,7 @@ public class SecuredStorageTest {
     }
 
     @Test
-    public void testRemoveExistingMechanism() {
+    public void testRemoveExistingMechanism() throws MechanismCreationException {
         DefaultStorageClient defaultStorage = new DefaultStorageClient(context);
 
         Account account = MockModelBuilder.createAccount(ISSUER, ACCOUNT_NAME);
@@ -274,7 +276,7 @@ public class SecuredStorageTest {
     }
 
     @Test
-    public void testStoreNotification() {
+    public void testStoreNotification() throws InvalidNotificationException, MechanismCreationException {
         DefaultStorageClient defaultStorage = new DefaultStorageClient(context);
         Calendar timeAdded = Calendar.getInstance();
 
@@ -300,7 +302,7 @@ public class SecuredStorageTest {
     }
 
     @Test
-    public void testStoreMultipleNotificationsForSameAccount() {
+    public void testStoreMultipleNotificationsForSameAccount() throws MechanismCreationException, InvalidNotificationException {
         DefaultStorageClient defaultStorage = new DefaultStorageClient(context);
 
         Calendar timeAdded1 = Calendar.getInstance();
@@ -337,7 +339,7 @@ public class SecuredStorageTest {
 
 
     @Test
-    public void testStoreMultipleNotificationsForDifferentAccounts() {
+    public void testStoreMultipleNotificationsForDifferentAccounts() throws MechanismCreationException, InvalidNotificationException {
         DefaultStorageClient defaultStorage = new DefaultStorageClient(context);
 
         Calendar timeAdded1 = Calendar.getInstance();
@@ -383,7 +385,7 @@ public class SecuredStorageTest {
     }
 
     @Test
-    public void testUpdateExistingNotification() {
+    public void testUpdateExistingNotification() throws MechanismCreationException, InvalidNotificationException {
         DefaultStorageClient defaultStorage = new DefaultStorageClient(context);
         Calendar timeAdded = Calendar.getInstance();
         boolean approved = false;
@@ -423,7 +425,7 @@ public class SecuredStorageTest {
     }
 
     @Test
-    public void testRemoveExistingNotification() {
+    public void testRemoveExistingNotification() throws MechanismCreationException, InvalidNotificationException {
         DefaultStorageClient defaultStorage = new DefaultStorageClient(context);
         Calendar timeAdded = Calendar.getInstance();
 

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/AuthenticatorManager.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/AuthenticatorManager.java
@@ -100,7 +100,7 @@ class AuthenticatorManager {
         // Retrieve account from StorageClient
         Account account = storageClient.getAccount(accountId);
 
-        // Sets mechanisms and/or notifications associated with this account
+        // Sets mechanisms associated with this account
         initializeAccount(account);
 
         return account;
@@ -171,6 +171,19 @@ class AuthenticatorManager {
         return storageClient.removeNotification(notification);
     }
 
+    PushNotification getNotification(String notificationId) {
+        Logger.debug(TAG, "Retrieving PushNotification with ID '%s' from the StorageClient.", notificationId);
+
+        // Retrieve notification from StorageClient
+        PushNotification notification = storageClient.getNotification(notificationId);
+
+        // Sets mechanism associated with this push notification
+        PushMechanism mechanism = (PushMechanism) getMechanism(notification);
+        notification.setPushMechanism(mechanism);
+
+        return notification;
+    }
+
     void registerForRemoteNotifications(String newDeviceToken) throws AuthenticatorException {
         if(this.deviceToken == null) {
             this.deviceToken = newDeviceToken;
@@ -217,7 +230,9 @@ class AuthenticatorManager {
     }
 
     List<PushNotification> getAllNotifications() {
-        return storageClient.getAllNotifications();
+        List<PushNotification> notificationList =  storageClient.getAllNotifications();
+        Collections.sort(notificationList);
+        return notificationList;
     }
 
     List<PushNotification> getAllNotifications(@NonNull Mechanism mechanism) {
@@ -239,14 +254,6 @@ class AuthenticatorManager {
             account.setMechanismList(mechanismList);
             for (Mechanism mechanism : mechanismList) {
                 mechanism.setAccount(account);
-                if(mechanism.getType().equals(Mechanism.PUSH)) {
-                    List<PushNotification> notificationList = storageClient.getAllNotificationsForMechanism(mechanism);
-                    for (PushNotification notification : notificationList) {
-                        notification.setPushMechanism(mechanism);
-                    }
-                    Collections.sort(notificationList);
-                    ((PushMechanism) mechanism).setPushNotificationList(notificationList);
-                }
             }
         }
     }

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/AuthenticatorManager.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/AuthenticatorManager.java
@@ -178,9 +178,10 @@ class AuthenticatorManager {
         PushNotification notification = storageClient.getNotification(notificationId);
 
         // Sets mechanism associated with this push notification
-        PushMechanism mechanism = (PushMechanism) getMechanism(notification);
-        notification.setPushMechanism(mechanism);
-
+        if(notification != null) {
+            PushMechanism mechanism = (PushMechanism) getMechanism(notification);
+            notification.setPushMechanism(mechanism);
+        }
         return notification;
     }
 

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/DefaultStorageClient.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/DefaultStorageClient.java
@@ -14,7 +14,6 @@ import android.content.SharedPreferences;
 import androidx.annotation.VisibleForTesting;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/DefaultStorageClient.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/DefaultStorageClient.java
@@ -14,6 +14,7 @@ import android.content.SharedPreferences;
 import androidx.annotation.VisibleForTesting;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -194,6 +195,12 @@ class DefaultStorageClient implements StorageClient {
         return notificationData.edit()
                 .putString(pushNotification.getId(), notificationJson)
                 .commit();
+    }
+
+    @Override
+    public PushNotification getNotification(String notificationId) {
+        String json = notificationData.getString(notificationId, null);
+        return PushNotification.deserialize(json);
     }
 
     @Override

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/FRAClient.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/FRAClient.java
@@ -212,6 +212,18 @@ public class FRAClient {
     }
 
     /**
+     * Get the PushNotification object with its id.  Returns {@code null} if PushNotification could
+     * not be found.
+     * This method also sets the {@link Mechanism} object
+     * associated with the PushNotification.
+     * @param notificationId The notification unique ID
+     * @return The account object
+     */
+    public PushNotification getNotification(@NonNull String notificationId) {
+        return this.authenticatorManager.getNotification(notificationId);
+    }
+
+    /**
      * Remove from the storage the {@link PushNotification} that was passed in.
      * @param notification The PushNotification object to delete
      * @return boolean as result of the operation

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/FRAClient.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/FRAClient.java
@@ -135,9 +135,9 @@ public class FRAClient {
     }
 
     /**
-     * Get the Account object with its id.  Returns {@code null} if Account could not be found.
-     * This method full initialize the {@link Mechanism} and/or {@link PushNotification} objects
-     * associated with the account.
+     * Get the Account object with its id. Identifier of Account object is "<issuer>-<accountName>"
+     * Returns {@code null} if Account could not be found.
+     * This method full initialize the {@link Mechanism} objects associated with the account.
      * @param accountId The account unique ID
      * @return The account object
      */
@@ -212,12 +212,11 @@ public class FRAClient {
     }
 
     /**
-     * Get the PushNotification object with its id.  Returns {@code null} if PushNotification could
-     * not be found.
-     * This method also sets the {@link Mechanism} object
-     * associated with the PushNotification.
+     * Get the PushNotification object with its id. Identifier of PushNotification object is "<mechanismUUID>-<timeAdded>"
+     * Returns {@code null} if PushNotification could not be found.
+     * This method also sets the {@link Mechanism} object associated with the PushNotification.
      * @param notificationId The notification unique ID
-     * @return The account object
+     * @return The PushNotification object
      */
     public PushNotification getNotification(@NonNull String notificationId) {
         return this.authenticatorManager.getNotification(notificationId);

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/HOTPMechanism.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/HOTPMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -7,6 +7,7 @@
 
 package org.forgerock.android.auth;
 
+import org.forgerock.android.auth.exception.MechanismCreationException;
 import org.forgerock.android.auth.exception.OathMechanismException;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -97,7 +98,7 @@ public class HOTPMechanism extends OathMechanism {
                     .setCounter(jsonObject.getLong("counter"))
                     .setTimeCreated(jsonObject.has("timeCreated") ? getDate(jsonObject.optLong("timeCreated")) : null)
                     .build();
-        } catch (JSONException e) {
+        } catch (JSONException | MechanismCreationException e) {
             return null;
         }
     }

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/ModelObject.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/ModelObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -8,6 +8,7 @@
 package org.forgerock.android.auth;
 
 import java.util.Calendar;
+import java.util.TimeZone;
 
 /**
  * Base class for objects which are a part of the Authenticator Model.
@@ -42,7 +43,7 @@ abstract class ModelObject<T> implements Comparable<T> {
     static Calendar getDate(long milliSeconds)
     {
         // Create a calendar object that will convert the date and time value in milliseconds to date.
-        Calendar calendar = Calendar.getInstance();
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         calendar.setTimeInMillis(milliSeconds);
         return calendar;
     }

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/NotificationFactory.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/NotificationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -144,7 +144,7 @@ class NotificationFactory {
     }
 
     private PushNotification generateNotification(String mechanismUid, String messageId,
-                                                  String base64Challenge, String amlbCookie, int ttl) {
+                                                  String base64Challenge, String amlbCookie, int ttl) throws InvalidNotificationException {
         Calendar timeReceived = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         Calendar timeExpired = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         timeExpired.add(Calendar.SECOND, ttl);

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/OathFactory.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/OathFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -50,7 +50,11 @@ class OathFactory extends MechanismFactory {
     protected void createFromUriParameters(int version, @NonNull String mechanismUID, @NonNull Map<String, String> map,
                                            @NonNull FRAListener<Mechanism> listener) {
         if (version == 1) {
-            this.buildOathMechanism(mechanismUID, map, listener);
+            try {
+                this.buildOathMechanism(mechanismUID, map, listener);
+            } catch (MechanismCreationException e) {
+                listener.onException(e);
+            }
         } else {
             Logger.warn(TAG, "Unknown version: %s", version);
             listener.onException(new MechanismCreationException("Unknown version: " + version));
@@ -58,7 +62,7 @@ class OathFactory extends MechanismFactory {
     }
 
     private void buildOathMechanism(String mechanismUID, Map<String, String> map,
-                                    FRAListener<Mechanism> listener) {
+                                    FRAListener<Mechanism> listener) throws MechanismCreationException {
         String issuer = map.get(MechanismParser.ISSUER);
         String accountName = map.get(MechanismParser.ACCOUNT_NAME);
 

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/OathMechanism.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/OathMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -9,6 +9,8 @@ package org.forgerock.android.auth;
 
 import androidx.annotation.VisibleForTesting;
 
+import org.forgerock.android.auth.exception.InvalidNotificationException;
+import org.forgerock.android.auth.exception.MechanismCreationException;
 import org.forgerock.android.auth.exception.OathMechanismException;
 import org.forgerock.android.auth.util.TimeKeeper;
 import org.json.JSONException;
@@ -200,8 +202,15 @@ public abstract class OathMechanism extends Mechanism {
         /**
          * Produce the described OathMechanism Token.
          * @return The built Token
+         * @throws MechanismCreationException If an issuer or accountName were not provided.
          */
-        protected OathMechanism build() {
+        protected OathMechanism build() throws MechanismCreationException {
+            if(issuer == null || issuer.isEmpty()) {
+                throw new MechanismCreationException("issuer cannot be empty or null.");
+            }
+            if(accountName == null || accountName.isEmpty()) {
+                throw new MechanismCreationException("accountName cannot be empty or null.");
+            }
             return buildOath();
         }
 

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/OathMechanism.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/OathMechanism.java
@@ -9,7 +9,6 @@ package org.forgerock.android.auth;
 
 import androidx.annotation.VisibleForTesting;
 
-import org.forgerock.android.auth.exception.InvalidNotificationException;
 import org.forgerock.android.auth.exception.MechanismCreationException;
 import org.forgerock.android.auth.exception.OathMechanismException;
 import org.forgerock.android.auth.util.TimeKeeper;

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/PushFactory.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/PushFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -117,16 +117,20 @@ class PushFactory extends MechanismFactory {
                 messageId, payload, new FRAListener<Void>() {
             @Override
             public void onSuccess(Void result) {
-                Mechanism push = PushMechanism.builder()
-                        .setMechanismUID(mechanismUID)
-                        .setIssuer(issuer)
-                        .setAccountName(accountName)
-                        .setAuthenticationEndpoint(authenticationEndpoint)
-                        .setRegistrationEndpoint(registrationEndpoint)
-                        .setSecret(base64Secret)
-                        .setTimeCreated(Calendar.getInstance(TimeZone.getTimeZone("UTC")))
-                        .build();
-                listener.onSuccess(push);
+                try {
+                    Mechanism push = PushMechanism.builder()
+                            .setMechanismUID(mechanismUID)
+                            .setIssuer(issuer)
+                            .setAccountName(accountName)
+                            .setAuthenticationEndpoint(authenticationEndpoint)
+                            .setRegistrationEndpoint(registrationEndpoint)
+                            .setSecret(base64Secret)
+                            .setTimeCreated(Calendar.getInstance(TimeZone.getTimeZone("UTC")))
+                            .build();
+                    listener.onSuccess(push);
+                } catch (MechanismCreationException e) {
+                    listener.onException(e);
+                }
             }
 
             @Override

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/PushMechanism.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/PushMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -7,6 +7,7 @@
 
 package org.forgerock.android.auth;
 
+import org.forgerock.android.auth.exception.MechanismCreationException;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -134,7 +135,7 @@ public class PushMechanism extends Mechanism {
                     .setRegistrationEndpoint(jsonObject.getString("registrationEndpoint"))
                     .setAuthenticationEndpoint(jsonObject.getString("authenticationEndpoint"))
                     .build();
-        } catch (JSONException e) {
+        } catch (JSONException | MechanismCreationException e) {
             return null;
         }
     }
@@ -228,9 +229,17 @@ public class PushMechanism extends Mechanism {
 
         /**
          * Produce the described Mechanism.
-         * @return The built Token
+         * @return The built Mechanism
+         * @throws MechanismCreationException If an issuer or accountName were not provided.
          */
-        protected PushMechanism build() {
+        protected PushMechanism build() throws MechanismCreationException {
+            if(issuer == null || issuer.isEmpty()) {
+                throw new MechanismCreationException("issuer cannot be empty or null.");
+            }
+            if(accountName == null || accountName.isEmpty()) {
+                throw new MechanismCreationException("accountName cannot be empty or null.");
+            }
+
             return new PushMechanism(mechanismUID, issuer, accountName, Mechanism.PUSH, secret,
                     registrationEndpoint, authenticationEndpoint, timeCreated);
         }

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/PushNotification.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/PushNotification.java
@@ -9,6 +9,7 @@ package org.forgerock.android.auth;
 
 import androidx.annotation.NonNull;
 
+import org.forgerock.android.auth.exception.InvalidNotificationException;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -269,7 +270,7 @@ public class PushNotification extends ModelObject<PushNotification> {
                     .setApproved(jsonObject.getBoolean("approved"))
                     .setPending(jsonObject.getBoolean("pending"))
                     .build();
-        } catch (JSONException e) {
+        } catch (JSONException | InvalidNotificationException e) {
             return null;
         }
     }
@@ -431,10 +432,14 @@ public class PushNotification extends ModelObject<PushNotification> {
         /**
          * Build the notification.
          * @return The final notification.
+         * @throws InvalidNotificationException if timeAdded or mechanismUID are not provided
          */
-        protected PushNotification build() {
+        protected PushNotification build() throws InvalidNotificationException {
             if(timeAdded == null) {
-                timeAdded = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+                throw new InvalidNotificationException("timeAdded cannot be null.");
+            }
+            if(mechanismUID == null) {
+                throw new InvalidNotificationException("mechanismUID cannot be null.");
             }
 
             return new PushNotification(mechanismUID, messageId, challenge, amlbCookie, timeAdded,

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/PushNotification.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/PushNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -61,7 +61,7 @@ public class PushNotification extends ModelObject<PushNotification> {
     private PushNotification(String mechanismUID, String messageId, String challenge, String amlbCookie,
                                Calendar timeAdded, Calendar timeExpired, long ttl, boolean approved,
                                boolean pending) {
-        this.id = mechanismUID + "-" + timeAdded;
+        this.id = mechanismUID + "-" + timeAdded.getTimeInMillis();
         this.mechanismUID = mechanismUID;
         this.messageId = messageId;
         this.challenge = challenge;
@@ -262,7 +262,7 @@ public class PushNotification extends ModelObject<PushNotification> {
                     .setMechanismUID(jsonObject.getString("mechanismUID"))
                     .setMessageId(jsonObject.getString("messageId"))
                     .setChallenge(jsonObject.getString("challenge"))
-                    .setAmlbCookie(jsonObject.has("amlbCookie") ? jsonObject.getString("amlbCookie"): null)
+                    .setAmlbCookie(jsonObject.has("amlbCookie") ? jsonObject.getString("amlbCookie") : null)
                     .setTimeAdded(jsonObject.has("timeAdded") ? getDate(jsonObject.optLong("timeAdded")) : null)
                     .setTimeExpired(jsonObject.has("timeExpired") ? getDate(jsonObject.optLong("timeExpired")) : null)
                     .setTtl(jsonObject.optLong("ttl", -1))
@@ -433,6 +433,10 @@ public class PushNotification extends ModelObject<PushNotification> {
          * @return The final notification.
          */
         protected PushNotification build() {
+            if(timeAdded == null) {
+                timeAdded = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+            }
+
             return new PushNotification(mechanismUID, messageId, challenge, amlbCookie, timeAdded,
                     timeExpired, ttl, approved, pending);
         }

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/StorageClient.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/StorageClient.java
@@ -99,6 +99,13 @@ public interface StorageClient {
     boolean setNotification(PushNotification pushNotification);
 
     /**
+     * Get the PushNotification object with its id
+     * @param notificationId The PushNotification unique ID
+     * @return The PushNotification object.
+     */
+    PushNotification getNotification(String notificationId);
+
+    /**
      * Whether the storage system currently contains any data.
      * @return True if the storage system is empty, false otherwise.
      */

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/TOTPMechanism.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/TOTPMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -7,6 +7,7 @@
 
 package org.forgerock.android.auth;
 
+import org.forgerock.android.auth.exception.MechanismCreationException;
 import org.forgerock.android.auth.exception.OathMechanismException;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -93,7 +94,7 @@ public class TOTPMechanism extends OathMechanism {
                     .setPeriod(jsonObject.getInt("period"))
                     .setTimeCreated(jsonObject.has("timeCreated") ? getDate(jsonObject.optLong("timeCreated")) : null)
                     .build();
-        } catch (JSONException e) {
+        } catch (JSONException | MechanismCreationException e) {
             return null;
         }
     }

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/exception/InvalidNotificationException.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/exception/InvalidNotificationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -8,7 +8,7 @@
 package org.forgerock.android.auth.exception;
 
 /**
- * Represents an error in attaching a PushNotification to a Mechanism.
+ * Represents an error on creating a PushNotification.
  */
 public class InvalidNotificationException extends Exception {
 

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/AuthenticatorManagerTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/AuthenticatorManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -38,6 +38,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -359,6 +360,30 @@ public class AuthenticatorManagerTest extends FRABaseTest {
 
         assertNotNull(notificationListFromStorage);
         assertEquals(notificationList.size(), notificationListFromStorage.size());
+    }
+
+    @Test
+    public void testShouldGetStoredNotificationByID() {
+        Account account = createAccount(ACCOUNT_NAME, ISSUER);
+        Mechanism push = createPushMechanism(ACCOUNT_NAME, ISSUER, MECHANISM_UID);
+        PushNotification notification = createPushNotification(MESSAGE_ID, push);
+
+        List<Mechanism> mechanismList= new ArrayList<>();
+        mechanismList.add(push);
+
+        List<PushNotification> notificationList = new ArrayList<>();
+        notificationList.add(createPushNotification(MESSAGE_ID, push));
+        notificationList.add(createPushNotification(OTHER_MESSAGE_ID, push));
+
+        given(storageClient.getAccount(any(String.class))).willReturn(account);
+        given(storageClient.getMechanismsForAccount(any(Account.class))).willReturn(mechanismList);
+        given(storageClient.getAllNotificationsForMechanism(any(Mechanism.class))).willReturn(notificationList);
+        given(storageClient.getNotification(anyString())).willReturn(notification);
+
+        PushNotification notificationFromStorage = authenticatorManager.getNotification(notification.getId());
+
+        assertNotNull(notificationFromStorage);
+        assertEquals(notification, notificationFromStorage);
     }
 
     @Test

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/CustomStorageClient.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/CustomStorageClient.java
@@ -90,6 +90,11 @@ public class CustomStorageClient implements StorageClient {
     }
 
     @Override
+    public PushNotification getNotification(String notificationId) {
+        return null;
+    }
+
+    @Override
     public boolean isEmpty() {
         return false;
     }

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/DefaultStorageClientTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/DefaultStorageClientTest.java
@@ -341,6 +341,55 @@ public class DefaultStorageClientTest extends FRABaseTest {
     }
 
     @Test
+    public void testNoNotificationFound() {
+        DefaultStorageClient defaultStorage = new DefaultStorageClient(context);
+        defaultStorage.setNotificationData(context.getApplicationContext()
+                .getSharedPreferences(TEST_SHARED_PREFERENCES_DATA_NOTIFICATIONS, Context.MODE_PRIVATE));
+
+        Calendar timeAdded = Calendar.getInstance();
+
+        PushNotification pushNotification = createPushNotification(MECHANISM_UID, MESSAGE_ID, CHALLENGE,
+                AMLB_COOKIE, timeAdded, TTL);
+        defaultStorage.setNotification(pushNotification);
+        PushNotification pushNotificationFromStorage = defaultStorage.getNotification("INVALID_ID");
+
+        assertNull(pushNotificationFromStorage);
+    }
+
+    @Test
+    public void testShouldGetNotificationById() {
+        DefaultStorageClient defaultStorage = new DefaultStorageClient(context);
+        defaultStorage.setAccountData(context.getApplicationContext()
+                .getSharedPreferences(TEST_SHARED_PREFERENCES_DATA_ACCOUNT, Context.MODE_PRIVATE));
+        defaultStorage.setMechanismData(context.getApplicationContext()
+                .getSharedPreferences(TEST_SHARED_PREFERENCES_DATA_MECHANISM, Context.MODE_PRIVATE));
+        defaultStorage.setNotificationData(context.getApplicationContext()
+                .getSharedPreferences(TEST_SHARED_PREFERENCES_DATA_NOTIFICATIONS, Context.MODE_PRIVATE));
+
+        Calendar timeAdded = Calendar.getInstance();
+
+        Account account = createAccountWithoutAdditionalData(ISSUER, ACCOUNT_NAME);
+        Mechanism mechanism = createPushMechanism(MECHANISM_UID, ISSUER, ACCOUNT_NAME, SECRET,
+                REGISTRATION_ENDPOINT, AUTHENTICATION_ENDPOINT);
+        PushNotification pushNotification = createPushNotification(MECHANISM_UID, MESSAGE_ID, CHALLENGE,
+                AMLB_COOKIE, timeAdded, TTL);
+
+        defaultStorage.setAccount(account);
+        defaultStorage.setMechanism(mechanism);
+        defaultStorage.setNotification(pushNotification);
+
+        Account accountFromStorage = defaultStorage.getAccount(account.getId());
+        PushMechanism pushMechanismFromStorage = (PushMechanism) defaultStorage.getMechanismsForAccount(accountFromStorage).get(0);
+        PushNotification pushNotificationFromStorage = defaultStorage.getNotification(pushNotification.getId());
+
+        assertNotNull(accountFromStorage);
+        assertNotNull(pushMechanismFromStorage);
+        assertNotNull(pushNotificationFromStorage);
+        assertEquals(pushNotificationFromStorage.getMechanismUID(), MECHANISM_UID);
+        assertEquals(pushNotificationFromStorage.getMessageId(), MESSAGE_ID);
+    }
+
+    @Test
     public void testStoreMultipleNotificationsForSameAccount() {
         DefaultStorageClient defaultStorage = new DefaultStorageClient(context);
         defaultStorage.setAccountData(context.getApplicationContext()

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/FRABaseTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/FRABaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -187,6 +187,7 @@ public abstract class FRABaseTest {
 
     public static PushNotification createPushNotification(String messageId, Mechanism push) {
         Calendar timeAdded = Calendar.getInstance();
+        timeAdded.setTimeInMillis(1629261902660L);
         PushNotification pushNotification = PushNotification.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setMessageId(messageId)

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/FRABaseTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/FRABaseTest.java
@@ -20,6 +20,8 @@ import com.nimbusds.jose.crypto.MACSigner;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 
+import org.forgerock.android.auth.exception.InvalidNotificationException;
+import org.forgerock.android.auth.exception.MechanismCreationException;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -60,6 +62,7 @@ public abstract class FRABaseTest {
     public static final String CHALLENGE = "fZl8wu9JBxdRQ7miq3dE0fbF0Bcdd+gRETUbtl6qSuM=";
     public static final String AMLB_COOKIE = "ZnJfc3NvX2FtbGJfcHJvZD0wMQ==";
     public static final long TTL = 120;
+    public static final long TIME_ADDED = 1629261902660L;
     public static final String TEST_SHARED_PREFERENCES_DATA_ACCOUNT = "test.DATA.ACCOUNT";
     public static final String TEST_SHARED_PREFERENCES_DATA_MECHANISM = "test.DATA.MECHANISM";
     public static final String TEST_SHARED_PREFERENCES_DATA_NOTIFICATIONS = "test.DATA.NOTIFICATIONS";
@@ -132,70 +135,95 @@ public abstract class FRABaseTest {
     }
 
     public static Mechanism createOathMechanism(String accountName, String issuer, String mechanismUid) {
-        OathMechanism mechanism = HOTPMechanism.builder()
-                .setMechanismUID(mechanismUid)
-                .setIssuer(issuer)
-                .setAccountName(accountName)
-                .setAlgorithm(ALGORITHM)
-                .setSecret(SECRET)
-                .setDigits(DIGITS)
-                .setCounter(COUNTER)
-                .build();
+        OathMechanism mechanism = null;
+        try {
+            mechanism = HOTPMechanism.builder()
+                    .setMechanismUID(mechanismUid)
+                    .setIssuer(issuer)
+                    .setAccountName(accountName)
+                    .setAlgorithm(ALGORITHM)
+                    .setSecret(SECRET)
+                    .setDigits(DIGITS)
+                    .setCounter(COUNTER)
+                    .build();
+        } catch (MechanismCreationException e) {
+            e.printStackTrace();
+        }
         return mechanism;
     }
 
     public static OathMechanism createOathMechanism(String mechanismUID, String issuer, String accountName, OathMechanism.TokenType oathType,
                                                     String algorithm, String secret, int digits, long counter, int period) {
-        OathMechanism oath = HOTPMechanism.builder()
-                .setMechanismUID(mechanismUID)
-                .setIssuer(issuer)
-                .setAccountName(accountName)
-                .setAlgorithm(algorithm)
-                .setSecret(secret)
-                .setDigits(digits)
-                .setCounter(counter)
-                .build();
+        OathMechanism oath = null;
+        try {
+            oath = HOTPMechanism.builder()
+                    .setMechanismUID(mechanismUID)
+                    .setIssuer(issuer)
+                    .setAccountName(accountName)
+                    .setAlgorithm(algorithm)
+                    .setSecret(secret)
+                    .setDigits(digits)
+                    .setCounter(counter)
+                    .build();
+        } catch (MechanismCreationException e) {
+            e.printStackTrace();
+        }
 
         return oath;
     }
 
     public static PushMechanism createPushMechanism(String mechanismUID, String issuer, String accountName, String secret,
                                                     String registrationEndpoint, String authenticationEndpoint) {
-        PushMechanism push = PushMechanism.builder()
-                .setMechanismUID(mechanismUID)
-                .setIssuer(issuer)
-                .setAccountName(accountName)
-                .setAuthenticationEndpoint(authenticationEndpoint)
-                .setRegistrationEndpoint(registrationEndpoint)
-                .setSecret(secret)
-                .build();
+        PushMechanism push = null;
+        try {
+            push = PushMechanism.builder()
+                    .setMechanismUID(mechanismUID)
+                    .setIssuer(issuer)
+                    .setAccountName(accountName)
+                    .setAuthenticationEndpoint(authenticationEndpoint)
+                    .setRegistrationEndpoint(registrationEndpoint)
+                    .setSecret(secret)
+                    .build();
+        } catch (MechanismCreationException e) {
+            e.printStackTrace();
+        }
 
         return push;
     }
 
     public static Mechanism createPushMechanism(String accountName, String issuer, String mechanismUid) {
-        PushMechanism mechanism = PushMechanism.builder()
-                .setMechanismUID(mechanismUid)
-                .setIssuer(issuer)
-                .setAccountName(accountName)
-                .setAuthenticationEndpoint(AUTHENTICATION_ENDPOINT)
-                .setRegistrationEndpoint(REGISTRATION_ENDPOINT)
-                .setSecret(SECRET)
-                .build();
+        PushMechanism mechanism = null;
+        try {
+            mechanism = PushMechanism.builder()
+                    .setMechanismUID(mechanismUid)
+                    .setIssuer(issuer)
+                    .setAccountName(accountName)
+                    .setAuthenticationEndpoint(AUTHENTICATION_ENDPOINT)
+                    .setRegistrationEndpoint(REGISTRATION_ENDPOINT)
+                    .setSecret(SECRET)
+                    .build();
+        } catch (MechanismCreationException e) {
+            e.printStackTrace();
+        }
         return mechanism;
     }
 
     public static PushNotification createPushNotification(String messageId, Mechanism push) {
         Calendar timeAdded = Calendar.getInstance();
         timeAdded.setTimeInMillis(1629261902660L);
-        PushNotification pushNotification = PushNotification.builder()
-                .setMechanismUID(MECHANISM_UID)
-                .setMessageId(messageId)
-                .setChallenge(CHALLENGE)
-                .setAmlbCookie(AMLB_COOKIE)
-                .setTimeAdded(timeAdded)
-                .setTtl(TTL)
-                .build();
+        PushNotification pushNotification = null;
+        try {
+            pushNotification = PushNotification.builder()
+                    .setMechanismUID(MECHANISM_UID)
+                    .setMessageId(messageId)
+                    .setChallenge(CHALLENGE)
+                    .setAmlbCookie(AMLB_COOKIE)
+                    .setTimeAdded(timeAdded)
+                    .setTtl(TTL)
+                    .build();
+        } catch (InvalidNotificationException e) {
+            e.printStackTrace();
+        }
         pushNotification.setPushMechanism(push);
         return pushNotification;
     }
@@ -206,17 +234,22 @@ public abstract class FRABaseTest {
                                                       long ttl, boolean approved,
                                                       boolean pending) {
 
-        PushNotification pushNotification = PushNotification.builder()
-                .setMechanismUID(mechanismUID)
-                .setMessageId(messageId)
-                .setChallenge(challenge)
-                .setAmlbCookie(amlbCookie)
-                .setTimeAdded(timeAdded)
-                .setTimeExpired(timeExpired)
-                .setTtl(ttl)
-                .setApproved(approved)
-                .setPending(pending)
-                .build();
+        PushNotification pushNotification = null;
+        try {
+            pushNotification = PushNotification.builder()
+                    .setMechanismUID(mechanismUID)
+                    .setMessageId(messageId)
+                    .setChallenge(challenge)
+                    .setAmlbCookie(amlbCookie)
+                    .setTimeAdded(timeAdded)
+                    .setTimeExpired(timeExpired)
+                    .setTtl(ttl)
+                    .setApproved(approved)
+                    .setPending(pending)
+                    .build();
+        } catch (InvalidNotificationException e) {
+            e.printStackTrace();
+        }
 
         return pushNotification;
     }
@@ -225,14 +258,19 @@ public abstract class FRABaseTest {
                                                       String challenge, String amlbCookie,
                                                       Calendar timeAdded, long ttl) {
 
-        PushNotification pushNotification = PushNotification.builder()
-                .setMechanismUID(mechanismUID)
-                .setMessageId(messageId)
-                .setChallenge(challenge)
-                .setAmlbCookie(amlbCookie)
-                .setTimeAdded(timeAdded)
-                .setTtl(ttl)
-                .build();
+        PushNotification pushNotification = null;
+        try {
+            pushNotification = PushNotification.builder()
+                    .setMechanismUID(mechanismUID)
+                    .setMessageId(messageId)
+                    .setChallenge(challenge)
+                    .setAmlbCookie(amlbCookie)
+                    .setTimeAdded(timeAdded)
+                    .setTtl(ttl)
+                    .build();
+        } catch (InvalidNotificationException e) {
+            e.printStackTrace();
+        }
 
         return pushNotification;
     }

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/FRAClientTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/FRAClientTest.java
@@ -638,6 +638,38 @@ public class FRAClientTest extends FRABaseTest {
     }
 
     @Test
+    public void testShouldNotGetStoredNotificationByID() throws Exception {
+        FRAClient fraClient = FRAClient.builder()
+                .withContext(context)
+                .withDeviceToken("s-o-m-e-t-o-k-e-n")
+                .withStorage(storageClient)
+                .start();
+
+        assertNotNull(fraClient);
+        assertNotNull(fraClient.getAuthenticatorManagerInstance());
+
+        Account account = createAccount(ACCOUNT_NAME, ISSUER);
+        Mechanism push = createPushMechanism(ACCOUNT_NAME, ISSUER, MECHANISM_UID);
+        PushNotification notification = createPushNotification(MESSAGE_ID, push);
+
+        List<Mechanism> mechanismList= new ArrayList<>();
+        mechanismList.add(push);
+
+        List<PushNotification> notificationList = new ArrayList<>();
+        notificationList.add(createPushNotification(MESSAGE_ID, push));
+        notificationList.add(createPushNotification(OTHER_MESSAGE_ID, push));
+
+        given(storageClient.getAccount(any(String.class))).willReturn(account);
+        given(storageClient.getMechanismsForAccount(any(Account.class))).willReturn(mechanismList);
+        given(storageClient.getAllNotificationsForMechanism(any(Mechanism.class))).willReturn(notificationList);
+        given(storageClient.getNotification(anyString())).willReturn(null);
+
+        PushNotification notificationFromStorage = fraClient.getNotification("INVALID_ID");
+
+        assertNull(notificationFromStorage);
+    }
+
+    @Test
     public void testGetAccountByIDFailNotFound() throws Exception {
         FRAClient fraClient = FRAClient.builder()
                 .withContext(context)

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/FRAClientTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/FRAClientTest.java
@@ -38,6 +38,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -601,6 +602,39 @@ public class FRAClientTest extends FRABaseTest {
 
         assertNotNull(notificationListFromStorage);
         assertEquals(notificationList.size(), notificationListFromStorage.size());
+    }
+
+    @Test
+    public void testShouldGetStoredNotificationByID() throws Exception {
+        FRAClient fraClient = FRAClient.builder()
+                .withContext(context)
+                .withDeviceToken("s-o-m-e-t-o-k-e-n")
+                .withStorage(storageClient)
+                .start();
+
+        assertNotNull(fraClient);
+        assertNotNull(fraClient.getAuthenticatorManagerInstance());
+
+        Account account = createAccount(ACCOUNT_NAME, ISSUER);
+        Mechanism push = createPushMechanism(ACCOUNT_NAME, ISSUER, MECHANISM_UID);
+        PushNotification notification = createPushNotification(MESSAGE_ID, push);
+
+        List<Mechanism> mechanismList= new ArrayList<>();
+        mechanismList.add(push);
+
+        List<PushNotification> notificationList = new ArrayList<>();
+        notificationList.add(createPushNotification(MESSAGE_ID, push));
+        notificationList.add(createPushNotification(OTHER_MESSAGE_ID, push));
+
+        given(storageClient.getAccount(any(String.class))).willReturn(account);
+        given(storageClient.getMechanismsForAccount(any(Account.class))).willReturn(mechanismList);
+        given(storageClient.getAllNotificationsForMechanism(any(Mechanism.class))).willReturn(notificationList);
+        given(storageClient.getNotification(anyString())).willReturn(notification);
+
+        PushNotification notificationFromStorage = fraClient.getNotification(notification.getId());
+
+        assertNotNull(notificationFromStorage);
+        assertEquals(notification, notificationFromStorage);
     }
 
     @Test

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/HOTPMechanismTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/HOTPMechanismTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -7,6 +7,7 @@
 
 package org.forgerock.android.auth;
 
+import org.forgerock.android.auth.exception.MechanismCreationException;
 import org.forgerock.android.auth.exception.OathMechanismException;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,7 +32,7 @@ public class HOTPMechanismTest extends FRABaseTest {
     }
 
     @Test
-    public void testCreateHOTPMechanism() {
+    public void testCreateHOTPMechanism() throws MechanismCreationException {
         OathMechanism mechanism = HOTPMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -53,8 +54,32 @@ public class HOTPMechanismTest extends FRABaseTest {
         assertEquals(((HOTPMechanism)mechanism).getCounter(), COUNTER);
     }
 
+    @Test (expected = MechanismCreationException.class)
+    public void testShouldFailToCreateHOTPMechanismMissingIssuer() throws MechanismCreationException {
+        HOTPMechanism.builder()
+                .setMechanismUID(MECHANISM_UID)
+                .setAccountName(ACCOUNT_NAME)
+                .setAlgorithm(ALGORITHM)
+                .setSecret(SECRET)
+                .setDigits(DIGITS)
+                .setCounter(COUNTER)
+                .build();
+    }
+
+    @Test (expected = MechanismCreationException.class)
+    public void testShouldFailToCreateHOTPMechanismMissingAccountName() throws MechanismCreationException {
+        HOTPMechanism.builder()
+                .setMechanismUID(MECHANISM_UID)
+                .setIssuer(ISSUER)
+                .setAlgorithm(ALGORITHM)
+                .setSecret(SECRET)
+                .setDigits(DIGITS)
+                .setCounter(COUNTER)
+                .build();
+    }
+
     @Test
-    public void testShouldBeEqualEquivalentHOTPMechanism() {
+    public void testShouldBeEqualEquivalentHOTPMechanism() throws MechanismCreationException {
         Mechanism mechanism1 = HOTPMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -80,7 +105,7 @@ public class HOTPMechanismTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldNotBeEqualDifferentHOTPMechanismWithAccountName() {
+    public void testShouldNotBeEqualDifferentHOTPMechanismWithAccountName() throws MechanismCreationException {
         Mechanism mechanism1 = HOTPMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -105,7 +130,7 @@ public class HOTPMechanismTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldNotBeEqualDifferentHOTPMechanismWithAccountIssuer() {
+    public void testShouldNotBeEqualDifferentHOTPMechanismWithAccountIssuer() throws MechanismCreationException {
         Mechanism mechanism1 = HOTPMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -130,7 +155,7 @@ public class HOTPMechanismTest extends FRABaseTest {
     }
 
     @Test
-    public void shouldHandleHOTPCorrectlyWith6Digits() throws OathMechanismException {
+    public void shouldHandleHOTPCorrectlyWith6Digits() throws OathMechanismException, MechanismCreationException {
         OathMechanism oath = HOTPMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -149,7 +174,7 @@ public class HOTPMechanismTest extends FRABaseTest {
     }
 
     @Test
-    public void shouldHandleHOTPCorrectlyWith8Digits() throws OathMechanismException {
+    public void shouldHandleHOTPCorrectlyWith8Digits() throws OathMechanismException, MechanismCreationException {
         OathMechanism oath = HOTPMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -168,7 +193,7 @@ public class HOTPMechanismTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldParseToJsonSuccessfully() {
+    public void testShouldParseToJsonSuccessfully() throws MechanismCreationException {
         String json = "{" +
                 "\"id\":\"issuer1-user1-otpauth\"," +
                 "\"issuer\":\"issuer1\"," +
@@ -199,7 +224,7 @@ public class HOTPMechanismTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldSerializeSuccessfully() {
+    public void testShouldSerializeSuccessfully() throws MechanismCreationException {
         String json = "{" +
                 "\"id\":\"issuer1-user1-otpauth\"," +
                 "\"issuer\":\"issuer1\"," +

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/NotificationFactoryTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/NotificationFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/OathCodeGeneratorTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/OathCodeGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -7,6 +7,7 @@
 
 package org.forgerock.android.auth;
 
+import org.forgerock.android.auth.exception.MechanismCreationException;
 import org.forgerock.android.auth.exception.OathMechanismException;
 import org.forgerock.android.auth.util.TimeKeeper;
 import org.junit.After;
@@ -55,7 +56,7 @@ public class OathCodeGeneratorTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldGenerateCodeHotpSHA1Algorithm() throws OathMechanismException {
+    public void testShouldGenerateCodeHotpSHA1Algorithm() throws OathMechanismException, MechanismCreationException {
         HOTPMechanism oath = (HOTPMechanism) HOTPMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -74,7 +75,7 @@ public class OathCodeGeneratorTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldGenerateCodeTotpSHA1Algorithm() throws OathMechanismException {
+    public void testShouldGenerateCodeTotpSHA1Algorithm() throws OathMechanismException, MechanismCreationException {
         TimeKeeper timeKeeper = new TimeKeeper() {
             long time = 1461773681957l;
             @Override
@@ -104,7 +105,7 @@ public class OathCodeGeneratorTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldGenerateCodeHotpSHA224Algorithm() throws OathMechanismException {
+    public void testShouldGenerateCodeHotpSHA224Algorithm() throws OathMechanismException, MechanismCreationException {
         HOTPMechanism oath = (HOTPMechanism) HOTPMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -123,7 +124,7 @@ public class OathCodeGeneratorTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldGenerateCodeTotpSHA224Algorithm() throws OathMechanismException {
+    public void testShouldGenerateCodeTotpSHA224Algorithm() throws OathMechanismException, MechanismCreationException {
         TimeKeeper timeKeeper = new TimeKeeper() {
             long time = 1461773681957l;
             @Override
@@ -153,7 +154,7 @@ public class OathCodeGeneratorTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldGenerateCodeHotpSHA256Algorithm() throws OathMechanismException {
+    public void testShouldGenerateCodeHotpSHA256Algorithm() throws OathMechanismException, MechanismCreationException {
         HOTPMechanism oath = (HOTPMechanism) HOTPMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -172,7 +173,7 @@ public class OathCodeGeneratorTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldGenerateCodeTotpSHA256Algorithm() throws OathMechanismException {
+    public void testShouldGenerateCodeTotpSHA256Algorithm() throws OathMechanismException, MechanismCreationException {
         TimeKeeper timeKeeper = new TimeKeeper() {
             long time = 1461773681957l;
             @Override
@@ -202,7 +203,7 @@ public class OathCodeGeneratorTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldGenerateCodeHotpSHA384Algorithm() throws OathMechanismException {
+    public void testShouldGenerateCodeHotpSHA384Algorithm() throws OathMechanismException, MechanismCreationException {
         HOTPMechanism oath = (HOTPMechanism) HOTPMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -221,7 +222,7 @@ public class OathCodeGeneratorTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldGenerateCodeTotpSHA384Algorithm() throws OathMechanismException {
+    public void testShouldGenerateCodeTotpSHA384Algorithm() throws OathMechanismException, MechanismCreationException {
         TimeKeeper timeKeeper = new TimeKeeper() {
             long time = 1461773681957l;
             @Override
@@ -251,7 +252,7 @@ public class OathCodeGeneratorTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldGenerateCodeHotpSHA512Algorithm() throws OathMechanismException {
+    public void testShouldGenerateCodeHotpSHA512Algorithm() throws OathMechanismException, MechanismCreationException {
         HOTPMechanism oath = (HOTPMechanism) HOTPMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -270,7 +271,7 @@ public class OathCodeGeneratorTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldGenerateCodeTotpSHA512Algorithm() throws OathMechanismException {
+    public void testShouldGenerateCodeTotpSHA512Algorithm() throws OathMechanismException, MechanismCreationException {
         TimeKeeper timeKeeper = new TimeKeeper() {
             long time = 1461773681957l;
             @Override
@@ -300,7 +301,7 @@ public class OathCodeGeneratorTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldGenerateCodeHotpMD5Algorithm() throws OathMechanismException {
+    public void testShouldGenerateCodeHotpMD5Algorithm() throws OathMechanismException, MechanismCreationException {
         HOTPMechanism oath = (HOTPMechanism) HOTPMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -319,7 +320,7 @@ public class OathCodeGeneratorTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldGenerateCodeTotpMD5Algorithm() throws OathMechanismException {
+    public void testShouldGenerateCodeTotpMD5Algorithm() throws OathMechanismException, MechanismCreationException {
         TimeKeeper timeKeeper = new TimeKeeper() {
             long time = 1461773681957l;
             @Override
@@ -349,7 +350,7 @@ public class OathCodeGeneratorTest extends FRABaseTest {
     }
 
     @Test
-    public void testHandleHOTPCorrectlyWith6Digits() throws OathMechanismException {
+    public void testHandleHOTPCorrectlyWith6Digits() throws OathMechanismException, MechanismCreationException {
         HOTPMechanism oath = (HOTPMechanism) HOTPMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -371,7 +372,7 @@ public class OathCodeGeneratorTest extends FRABaseTest {
     }
 
     @Test
-    public void testHandleHOTPCorrectlyWith8Digits() throws OathMechanismException {
+    public void testHandleHOTPCorrectlyWith8Digits() throws OathMechanismException, MechanismCreationException {
         HOTPMechanism oath = (HOTPMechanism) HOTPMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -393,7 +394,7 @@ public class OathCodeGeneratorTest extends FRABaseTest {
     }
 
     @Test
-    public void testHandleTOTPCorrectly() throws OathMechanismException {
+    public void testHandleTOTPCorrectly() throws OathMechanismException, MechanismCreationException {
 
         TimeKeeper timeKeeper = new TimeKeeper() {
             long time = 1461773681957l;
@@ -428,7 +429,7 @@ public class OathCodeGeneratorTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldFailToHandleHOTPInvalidAlgorithm() {
+    public void testShouldFailToHandleHOTPInvalidAlgorithm() throws MechanismCreationException {
         HOTPMechanism oath = (HOTPMechanism) HOTPMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -450,7 +451,7 @@ public class OathCodeGeneratorTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldFailToHandleHOTPInvalidSecret() {
+    public void testShouldFailToHandleHOTPInvalidSecret() throws MechanismCreationException {
         HOTPMechanism oath = (HOTPMechanism) HOTPMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/OathMechanismTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/OathMechanismTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -7,6 +7,7 @@
 
 package org.forgerock.android.auth;
 
+import org.forgerock.android.auth.exception.MechanismCreationException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -21,7 +22,7 @@ import static org.mockito.Mockito.mock;
 public class OathMechanismTest extends FRABaseTest {
 
     @Test
-    public void testShouldParseHOTPToJsonSuccessfully() {
+    public void testShouldParseHOTPToJsonSuccessfully() throws MechanismCreationException {
         String json = "{" +
                 "\"id\":\"issuer1-user1-otpauth\"," +
                 "\"issuer\":\"issuer1\"," +
@@ -52,7 +53,7 @@ public class OathMechanismTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldParseTOTPToJsonSuccessfully() {
+    public void testShouldParseTOTPToJsonSuccessfully() throws MechanismCreationException {
         String json = "{" +
                 "\"id\":\"issuer1-user1-otpauth\"," +
                 "\"issuer\":\"issuer1\"," +

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/PushMechanismTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/PushMechanismTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -7,12 +7,16 @@
 
 package org.forgerock.android.auth;
 
+import org.forgerock.android.auth.exception.InvalidNotificationException;
+import org.forgerock.android.auth.exception.MechanismCreationException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
+import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -24,7 +28,7 @@ import static org.junit.Assert.assertTrue;
 public class PushMechanismTest extends FRABaseTest {
 
     @Test
-    public void testCreatePushMechanismSuccessfuly() {
+    public void testCreatePushMechanismSuccessfuly() throws MechanismCreationException {
         PushMechanism mechanism = PushMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -43,8 +47,30 @@ public class PushMechanismTest extends FRABaseTest {
         assertEquals(mechanism.getSecret(), SECRET);
     }
 
+    @Test (expected = MechanismCreationException.class)
+    public void testShouldFailToCreatePushMechanismMissingIssuer() throws MechanismCreationException {
+        PushMechanism mechanism = PushMechanism.builder()
+                .setMechanismUID(MECHANISM_UID)
+                .setAccountName(ACCOUNT_NAME)
+                .setAuthenticationEndpoint(AUTHENTICATION_ENDPOINT)
+                .setRegistrationEndpoint(REGISTRATION_ENDPOINT)
+                .setSecret(SECRET)
+                .build();
+    }
+
+    @Test (expected = MechanismCreationException.class)
+    public void testShouldFailToCreatePushMechanismMissingAccountName() throws MechanismCreationException {
+        PushMechanism mechanism = PushMechanism.builder()
+                .setMechanismUID(MECHANISM_UID)
+                .setIssuer(ISSUER)
+                .setAuthenticationEndpoint(AUTHENTICATION_ENDPOINT)
+                .setRegistrationEndpoint(REGISTRATION_ENDPOINT)
+                .setSecret(SECRET)
+                .build();
+    }
+
     @Test
-    public void testShouldEqualEquivalentPushMechanism() {
+    public void testShouldEqualEquivalentPushMechanism() throws MechanismCreationException {
         Mechanism mechanism1 = PushMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -68,7 +94,7 @@ public class PushMechanismTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldNotEqualDifferentPushMechanismWithAccountName() {
+    public void testShouldNotEqualDifferentPushMechanismWithAccountName() throws MechanismCreationException {
         Mechanism mechanism1 = PushMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -91,7 +117,7 @@ public class PushMechanismTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldNotEqualDifferentPushMechanismWithAccountIssuer() {
+    public void testShouldNotEqualDifferentPushMechanismWithAccountIssuer() throws MechanismCreationException {
         Mechanism mechanism1 = PushMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -114,7 +140,7 @@ public class PushMechanismTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldReturnAllNotifications() {
+    public void testShouldReturnAllNotifications() throws MechanismCreationException {
         PushMechanism mechanism = PushMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -136,7 +162,7 @@ public class PushMechanismTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldReturnOnlyPendingNotifications() {
+    public void testShouldReturnOnlyPendingNotifications() throws MechanismCreationException, InvalidNotificationException {
         PushMechanism mechanism = PushMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -146,6 +172,7 @@ public class PushMechanismTest extends FRABaseTest {
                 .setSecret(SECRET)
                 .build();
 
+        Calendar timeAdded = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         PushNotification pushNotification1 = createPushNotification(MESSAGE_ID, mechanism);
         PushNotification pushNotification2 = createPushNotification(OTHER_MESSAGE_ID, mechanism);
         PushNotification pushNotification3 = PushNotification.builder()
@@ -153,6 +180,7 @@ public class PushMechanismTest extends FRABaseTest {
                 .setMessageId("s-o-m-e-i-d")
                 .setChallenge(CHALLENGE)
                 .setAmlbCookie(AMLB_COOKIE)
+                .setTimeAdded(timeAdded)
                 .setPending(false)
                 .setApproved(true)
                 .setTtl(TTL)
@@ -168,7 +196,7 @@ public class PushMechanismTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldParseToJsonSuccessfully() {
+    public void testShouldParseToJsonSuccessfully() throws MechanismCreationException {
         String json = "{" +
                 "\"id\":\"issuer1-user1-pushauth\"," +
                 "\"issuer\":\"issuer1\"," +
@@ -196,7 +224,7 @@ public class PushMechanismTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldSerializeSuccessfully() {
+    public void testShouldSerializeSuccessfully() throws MechanismCreationException {
         String json = "{" +
                 "\"id\":\"issuer1-user1-pushauth\"," +
                 "\"issuer\":\"issuer1\"," +

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/PushNotificationTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/PushNotificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -19,6 +19,7 @@ import org.robolectric.RobolectricTestRunner;
 
 import java.io.IOException;
 import java.util.Calendar;
+import java.util.TimeZone;
 
 import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.MockResponse;
@@ -361,20 +362,25 @@ public class PushNotificationTest extends FRABaseTest {
     @Test
     public void testShouldParseToJsonSuccessfully() {
         String json = "{" +
-                "\"id\":\"b162b325-ebb1-48e0-8ab7-b38cf341da95-null\"," +
+                "\"id\":\"b162b325-ebb1-48e0-8ab7-b38cf341da95-1629261902660\"," +
                 "\"mechanismUID\":\"b162b325-ebb1-48e0-8ab7-b38cf341da95\"," +
                 "\"messageId\":\"AUTHENTICATE:63ca6f18-7cfb-4198-bcd0-ac5041fbbea01583798229441\"," +
                 "\"challenge\":\"REMOVED\"," +
                 "\"amlbCookie\":\"REMOVED\"," +
+                "\"timeAdded\":1629261902660," +
                 "\"ttl\":120," +
                 "\"approved\":false," +
                 "\"pending\":true}";
+
+        Calendar timeAdded = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        timeAdded.setTimeInMillis(1629261902660L);
 
         PushNotification pushNotification = PushNotification.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setMessageId(MESSAGE_ID)
                 .setChallenge(CHALLENGE)
                 .setAmlbCookie(AMLB_COOKIE)
+                .setTimeAdded(timeAdded)
                 .setTtl(TTL)
                 .build();
 
@@ -387,20 +393,25 @@ public class PushNotificationTest extends FRABaseTest {
     @Test
     public void testShouldSerializeSuccessfully() {
         String json = "{" +
-                "\"id\":\"b162b325-ebb1-48e0-8ab7-b38cf341da95-null\"," +
+                "\"id\":\"b162b325-ebb1-48e0-8ab7-b38cf341da95-1629261902660\"," +
                 "\"mechanismUID\":\"b162b325-ebb1-48e0-8ab7-b38cf341da95\"," +
                 "\"messageId\":\"AUTHENTICATE:63ca6f18-7cfb-4198-bcd0-ac5041fbbea01583798229441\"," +
                 "\"challenge\":\"fZl8wu9JBxdRQ7miq3dE0fbF0Bcdd+gRETUbtl6qSuM=\"," +
                 "\"amlbCookie\":\"ZnJfc3NvX2FtbGJfcHJvZD0wMQ==\"," +
+                "\"timeAdded\":1629261902660," +
                 "\"ttl\":120," +
                 "\"approved\":false," +
                 "\"pending\":true}";
+
+        Calendar timeAdded = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        timeAdded.setTimeInMillis(1629261902660L);
 
         PushNotification pushNotification = PushNotification.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setMessageId(MESSAGE_ID)
                 .setChallenge(CHALLENGE)
                 .setAmlbCookie(AMLB_COOKIE)
+                .setTimeAdded(timeAdded)
                 .setTtl(TTL)
                 .build();
 
@@ -413,7 +424,7 @@ public class PushNotificationTest extends FRABaseTest {
     @Test
     public void testShouldDeserializeSuccessfully() {
         String json = "{" +
-                "\"id\":\"b162b325-ebb1-48e0-8ab7-b38cf341da95-null\"," +
+                "\"id\":\"b162b325-ebb1-48e0-8ab7-b38cf341da95-1629261902660\"," +
                 "\"mechanismUID\":\"b162b325-ebb1-48e0-8ab7-b38cf341da95\"," +
                 "\"messageId\":\"AUTHENTICATE:63ca6f18-7cfb-4198-bcd0-ac5041fbbea01583798229441\"," +
                 "\"challenge\":\"fZl8wu9JBxdRQ7miq3dE0fbF0Bcdd+gRETUbtl6qSuM=\"," +

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/PushNotificationTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/PushNotificationTest.java
@@ -9,6 +9,8 @@ package org.forgerock.android.auth;
 
 import com.google.firebase.messaging.RemoteMessage;
 
+import org.forgerock.android.auth.exception.InvalidNotificationException;
+import org.forgerock.android.auth.exception.MechanismParsingException;
 import org.forgerock.android.auth.exception.PushMechanismException;
 import org.junit.After;
 import org.junit.Assert;
@@ -52,7 +54,7 @@ public class PushNotificationTest extends FRABaseTest {
     }
 
     @Test
-    public void testCreateNotificationSuccessfuly() {
+    public void testCreateNotificationSuccessfuly() throws InvalidNotificationException {
         Calendar timeAdded = Calendar.getInstance();
         Calendar timeExpired = Calendar.getInstance();
 
@@ -76,7 +78,7 @@ public class PushNotificationTest extends FRABaseTest {
     }
 
     @Test
-    public void testCreateNotificationWithOptionalParametersSuccessfuly() {
+    public void testCreateNotificationWithOptionalParametersSuccessfuly() throws InvalidNotificationException {
         Calendar timeAdded = Calendar.getInstance();
         Calendar timeExpired = Calendar.getInstance();
         long time = timeExpired.getTimeInMillis();
@@ -107,8 +109,31 @@ public class PushNotificationTest extends FRABaseTest {
         assertEquals(pushNotification.isExpired(), false);
     }
 
+    @Test (expected = InvalidNotificationException.class)
+    public void testShouldFailToCreateNotificationTimeAddedMissing() throws InvalidNotificationException {
+        PushNotification.builder()
+                .setMechanismUID(MECHANISM_UID)
+                .setMessageId(MESSAGE_ID)
+                .setChallenge(CHALLENGE)
+                .setAmlbCookie(AMLB_COOKIE)
+                .setTtl(TTL)
+                .build();
+    }
+
+    @Test (expected = InvalidNotificationException.class)
+    public void testShouldFailToCreateNotificationMechanismUIDMissing() throws InvalidNotificationException {
+        Calendar timeAdded = Calendar.getInstance();
+        PushNotification.builder()
+                .setMessageId(MESSAGE_ID)
+                .setChallenge(CHALLENGE)
+                .setAmlbCookie(AMLB_COOKIE)
+                .setTimeAdded(timeAdded)
+                .setTtl(TTL)
+                .build();
+    }
+
     @Test
-    public void testShouldBeEqualEquivalentNotification() {
+    public void testShouldBeEqualEquivalentNotification() throws InvalidNotificationException {
         Calendar timeAdded = Calendar.getInstance();
         PushNotification pushNotification1 = PushNotification.builder()
                 .setMechanismUID(MECHANISM_UID)
@@ -133,7 +158,7 @@ public class PushNotificationTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldNotBeEqualNotificationWithDifferentMechanismUID() {
+    public void testShouldNotBeEqualNotificationWithDifferentMechanismUID() throws InvalidNotificationException {
         Calendar timeAdded = Calendar.getInstance();
         PushNotification pushNotification1 = PushNotification.builder()
                 .setMechanismUID(MECHANISM_UID)
@@ -157,7 +182,7 @@ public class PushNotificationTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldNotBeEqualNotificationWithDifferentTimeAdded() {
+    public void testShouldNotBeEqualNotificationWithDifferentTimeAdded() throws InvalidNotificationException {
         Calendar timeAdded1 = Calendar.getInstance();
 
         long time = timeAdded1.getTimeInMillis();
@@ -360,7 +385,7 @@ public class PushNotificationTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldParseToJsonSuccessfully() {
+    public void testShouldParseToJsonSuccessfully() throws InvalidNotificationException {
         String json = "{" +
                 "\"id\":\"b162b325-ebb1-48e0-8ab7-b38cf341da95-1629261902660\"," +
                 "\"mechanismUID\":\"b162b325-ebb1-48e0-8ab7-b38cf341da95\"," +
@@ -391,7 +416,7 @@ public class PushNotificationTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldSerializeSuccessfully() {
+    public void testShouldSerializeSuccessfully() throws InvalidNotificationException {
         String json = "{" +
                 "\"id\":\"b162b325-ebb1-48e0-8ab7-b38cf341da95-1629261902660\"," +
                 "\"mechanismUID\":\"b162b325-ebb1-48e0-8ab7-b38cf341da95\"," +
@@ -429,6 +454,7 @@ public class PushNotificationTest extends FRABaseTest {
                 "\"messageId\":\"AUTHENTICATE:63ca6f18-7cfb-4198-bcd0-ac5041fbbea01583798229441\"," +
                 "\"challenge\":\"fZl8wu9JBxdRQ7miq3dE0fbF0Bcdd+gRETUbtl6qSuM=\"," +
                 "\"amlbCookie\":\"ZnJfc3NvX2FtbGJfcHJvZD0wMQ==\"," +
+                "\"timeAdded\":1629261902660," +
                 "\"ttl\":120," +
                 "\"approved\":false," +
                 "\"pending\":true}";

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/PushResponderTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/PushResponderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -8,6 +8,8 @@
 package org.forgerock.android.auth;
 
 import org.forgerock.android.auth.exception.ChallengeResponseException;
+import org.forgerock.android.auth.exception.InvalidNotificationException;
+import org.forgerock.android.auth.exception.MechanismCreationException;
 import org.forgerock.android.auth.exception.PushMechanismException;
 import org.json.JSONObject;
 import org.junit.After;
@@ -265,7 +267,7 @@ public class PushResponderTest extends FRABaseTest {
         assertEquals(hash, jwtSignature);
     }
 
-    private PushNotification newPushNotification() {
+    private PushNotification newPushNotification() throws InvalidNotificationException, MechanismCreationException {
         Calendar time = Calendar.getInstance();
         PushNotification pushNotification = PushNotification.builder()
                 .setMechanismUID(MECHANISM_UID)
@@ -284,7 +286,7 @@ public class PushResponderTest extends FRABaseTest {
         return pushNotification;
     }
 
-    private PushMechanism newPushMechanism() {
+    private PushMechanism newPushMechanism() throws MechanismCreationException {
         HttpUrl baseUrl = server.url("/");
         PushMechanism push = PushMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/TOTPMechanismTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/TOTPMechanismTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -7,6 +7,7 @@
 
 package org.forgerock.android.auth;
 
+import org.forgerock.android.auth.exception.MechanismCreationException;
 import org.forgerock.android.auth.exception.OathMechanismException;
 import org.forgerock.android.auth.util.TimeKeeper;
 import org.junit.Before;
@@ -32,7 +33,7 @@ public class TOTPMechanismTest extends FRABaseTest {
     }
 
     @Test
-    public void testCreateTOTPMechanism() {
+    public void testCreateTOTPMechanism() throws MechanismCreationException {
         OathMechanism mechanism = TOTPMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -54,8 +55,32 @@ public class TOTPMechanismTest extends FRABaseTest {
         assertEquals(((TOTPMechanism)mechanism).getPeriod(), PERIOD);
     }
 
+    @Test (expected = MechanismCreationException.class)
+    public void testShouldFailToCreateTOTPMechanismMissingIssuer() throws MechanismCreationException {
+        TOTPMechanism.builder()
+                .setMechanismUID(MECHANISM_UID)
+                .setAccountName(ACCOUNT_NAME)
+                .setAlgorithm(ALGORITHM)
+                .setSecret(SECRET)
+                .setDigits(DIGITS)
+                .setPeriod(PERIOD)
+                .build();
+    }
+
+    @Test (expected = MechanismCreationException.class)
+    public void testShouldFailToCreateTOTPMechanismMissingAccountName() throws MechanismCreationException {
+        TOTPMechanism.builder()
+                .setMechanismUID(MECHANISM_UID)
+                .setIssuer(ISSUER)
+                .setAlgorithm(ALGORITHM)
+                .setSecret(SECRET)
+                .setDigits(DIGITS)
+                .setPeriod(PERIOD)
+                .build();
+    }
+
     @Test
-    public void testShouldBeEqualEquivalentTOTPMechanism() {
+    public void testShouldBeEqualEquivalentTOTPMechanism() throws MechanismCreationException {
         Mechanism mechanism1 = TOTPMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -81,7 +106,7 @@ public class TOTPMechanismTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldNotBeEqualDifferentTOTPMechanismWithAccountName() {
+    public void testShouldNotBeEqualDifferentTOTPMechanismWithAccountName() throws MechanismCreationException {
         Mechanism mechanism1 = TOTPMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -106,7 +131,7 @@ public class TOTPMechanismTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldNotBeEqualDifferentTOTPMechanismWithAccountIssuer() {
+    public void testShouldNotBeEqualDifferentTOTPMechanismWithAccountIssuer() throws MechanismCreationException {
         Mechanism mechanism1 = TOTPMechanism.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setIssuer(ISSUER)
@@ -131,7 +156,7 @@ public class TOTPMechanismTest extends FRABaseTest {
     }
 
     @Test
-    public void shouldHandleTOTPCorrectly() throws OathMechanismException {
+    public void shouldHandleTOTPCorrectly() throws OathMechanismException, MechanismCreationException {
         TimeKeeper timeKeeper = new TimeKeeper() {
             long time = 1461773681957l;
             @Override
@@ -164,7 +189,7 @@ public class TOTPMechanismTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldParseToJsonSuccessfully() {
+    public void testShouldParseToJsonSuccessfully() throws MechanismCreationException {
         String json = "{" +
                 "\"id\":\"issuer1-user1-otpauth\"," +
                 "\"issuer\":\"issuer1\"," +
@@ -195,7 +220,7 @@ public class TOTPMechanismTest extends FRABaseTest {
     }
 
     @Test
-    public void testShouldSerializeSuccessfully() {
+    public void testShouldSerializeSuccessfully() throws MechanismCreationException {
         String json = "{" +
                 "\"id\":\"issuer1-user1-otpauth\"," +
                 "\"issuer\":\"issuer1\"," +


### PR DESCRIPTION
SDKS-1187 Authenticator SDK notification enhancements

**Summary of changes:**
- Make notificationId use date time as plain text
- Remove initialization of PushNotification objects associated with mechanisms inside AuthenticatorManager#getAllAccounts
- Sort list on AuthenticatorManager#getAllNotifications
- Add validation for the primary keys on the build of Models
- Updated unit tests