### PR TITLE
SDKS-1141 Unlock device is not required for data decryption.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Added
 - Introduce `FRLifecycle` and exposed interfaces to allow custom Native SSO implementation. [SDKS-1140]
+- Unlock device is not required for data decryption. [SDKS-1141]
 
 # Version 3.0.0
 

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/AccountDataRepository.java
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/AccountDataRepository.java
@@ -7,18 +7,17 @@
 
 package org.forgerock.android.auth;
 
+import static org.forgerock.android.auth.Encryptor.getEncryptor;
+
 import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.annotation.TargetApi;
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.util.Base64;
 
 import androidx.annotation.NonNull;
 
 import lombok.Builder;
-
-import static org.forgerock.android.auth.Encryptor.getEncryptor;
 
 /**
  * A Repository that store data in {@link AccountManager}
@@ -67,13 +66,13 @@ class AccountDataRepository implements DataRepository, AccountAware, KeyUpdatedL
             String encryptedData = accountManager.getUserData(account, key);
             if (encryptedData != null) {
                 return new String(encryptor.decrypt(Base64.decode(encryptedData, Base64.DEFAULT)));
-            } else {
-                return null;
             }
-        } catch (Exception e) {
+        } catch (EncryptionException e) {
             Logger.warn(TAG, e, "Failed to decrypt data");
-            return null;
+            //The data are not valid.
+            deleteAll();
         }
+        return null;
     }
 
     @Override

--- a/forgerock-core/src/main/java/org/forgerock/android/auth/AbstractSymmetricEncryptor.java
+++ b/forgerock-core/src/main/java/org/forgerock/android/auth/AbstractSymmetricEncryptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -50,7 +50,7 @@ abstract class AbstractSymmetricEncryptor implements Encryptor {
             byte[] mac = computeMac(keyAlias, encryptedData);
             encryptedData = concatArrays(mac, iv, encryptedData);
         } catch (Exception e) {
-            throw new RuntimeException(e.getMessage(), e);
+            throw new EncryptionException(e);
         }
         return encryptedData;
     }
@@ -61,7 +61,7 @@ abstract class AbstractSymmetricEncryptor implements Encryptor {
         try {
             cipher = Cipher.getInstance(AES_GCM_NO_PADDING);
         } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
-            throw new RuntimeException("Error while getting an cipher instance", e);
+            throw new EncryptionException("Error while getting an cipher instance", e);
         }
 
         int ivLength = IV_LENGTH;
@@ -89,7 +89,7 @@ abstract class AbstractSymmetricEncryptor implements Encryptor {
             cipher.init(Cipher.DECRYPT_MODE, getSecretKey(), ivParams);
             return cipher.doFinal(encryptedData);
         } catch (Exception e) {
-            throw new RuntimeException(e.getMessage(), e);
+            throw new EncryptionException(e.getMessage(), e);
         }
     }
 
@@ -100,7 +100,7 @@ abstract class AbstractSymmetricEncryptor implements Encryptor {
             mac.init(sk);
             return mac.doFinal(cipherText);
         } catch (NoSuchAlgorithmException | InvalidKeyException e) {
-            throw new RuntimeException(e);
+            throw new EncryptionException(e);
         }
     }
 

--- a/forgerock-core/src/main/java/org/forgerock/android/auth/AndroidPEncryptor.java
+++ b/forgerock-core/src/main/java/org/forgerock/android/auth/AndroidPEncryptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -32,7 +32,8 @@ class AndroidPEncryptor extends AndroidNEncryptor {
 
     AndroidPEncryptor(Context context, @NonNull String keyAlias, KeyUpdatedListener listener) {
         super(keyAlias, listener);
-        specBuilder.setUnlockedDeviceRequired(true);
+        //Allow access the data during screen lock
+        specBuilder.setUnlockedDeviceRequired(false);
 
         if (context.getPackageManager().hasSystemFeature(FEATURE_STRONGBOX_KEYSTORE)) {
             Logger.debug(TAG, "Strong box keystore is used.");

--- a/forgerock-core/src/main/java/org/forgerock/android/auth/AsymmetricEncryptor.java
+++ b/forgerock-core/src/main/java/org/forgerock/android/auth/AsymmetricEncryptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 -2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -58,7 +58,7 @@ class AsymmetricEncryptor implements Encryptor {
 
             return cipher.doFinal(data);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new EncryptionException(e);
         }
     }
 
@@ -78,7 +78,7 @@ class AsymmetricEncryptor implements Encryptor {
 
             return cipher.doFinal(encryptedData);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new EncryptionException(e);
         }
     }
 
@@ -137,7 +137,7 @@ class AsymmetricEncryptor implements Encryptor {
         Intent authIntent = km.createConfirmDeviceCredentialIntent(null, null);
         boolean keyguardEnabled = km.isKeyguardSecure() && authIntent != null;
         if (keyguardEnabled) {
-            //key pair should bebe encrypted at rest
+            //key pair should be encrypted at rest
             builder.setEncryptionRequired();
         }
         return builder.build();

--- a/forgerock-core/src/main/java/org/forgerock/android/auth/EncryptionException.java
+++ b/forgerock-core/src/main/java/org/forgerock/android/auth/EncryptionException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 ForgeRock. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package org.forgerock.android.auth;
+
+/**
+ * An EncryptionException should be thrown for any problems related to encryption.
+ */
+public class EncryptionException extends RuntimeException {
+
+    public EncryptionException() {
+    }
+
+    public EncryptionException(String message) {
+        super(message);
+    }
+
+    public EncryptionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public EncryptionException(Throwable cause) {
+        super(cause);
+    }
+
+    public EncryptionException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/forgerock-core/src/main/java/org/forgerock/android/auth/SecuredSharedPreferences.java
+++ b/forgerock-core/src/main/java/org/forgerock/android/auth/SecuredSharedPreferences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -35,6 +35,7 @@ import static org.forgerock.android.auth.Encryptor.getEncryptor;
  * An implementation of {@link SharedPreferences} that encrypts values.
  */
 public class SecuredSharedPreferences implements SharedPreferences, KeyUpdatedListener {
+    public static final String TAG = SecuredSharedPreferences.class.getName();
 
     private static final int STRING_TYPE = 0;
     private static final int STRING_SET_TYPE = 1;
@@ -211,13 +212,10 @@ public class SecuredSharedPreferences implements SharedPreferences, KeyUpdatedLi
     private String decrypt(@lombok.NonNull String data) {
         try {
             return new String(encryptor.decrypt(Base64.decode(data, Base64.DEFAULT)));
-        } catch (Exception e) {
+        } catch (EncryptionException e) {
             //Failed to decrypt the data, reset the encryptor
-            try {
-                encryptor.reset();
-            } catch (Exception ex) {
-                throw new RuntimeException(ex);
-            }
+            Logger.warn(TAG, "Failed to decrypt the data." );
+            edit().clear().commit();
             return null;
         }
     }


### PR DESCRIPTION
For Android 12, if setUnlockedDeviceRequired is set to true for keys, device screen lock is required. We. want to support device without screen lock.
Enhance data clean up when failed to decrypt data.