### PR TITLE
SDKS-1486 BooleanAttributeInputCallback is not Serializable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 #### Added
 - Google Sign-In Security Enhancement [SDKS-1252]
 - WebAuthn Registration & Authentication prompt not shown on second invocation on Single Activity App [SDKS-1297]
+  
+#### Fixed
+- AbstractValidatedCallback is not serializable [SDKS-1486]
 
 ## [3.1.2]
 #### Added

--- a/forgerock-auth/build.gradle
+++ b/forgerock-auth/build.gradle
@@ -113,6 +113,8 @@ dependencies {
     testImplementation 'com.google.android.gms:play-services-fido:18.1.0'
     testImplementation 'com.google.android.gms:play-services-auth:19.2.0'
     testImplementation 'com.facebook.android:facebook-login:7.1.0'
+    testImplementation 'com.google.android.gms:play-services-safetynet:17.0.0'
+    testImplementation 'org.jeasy:easy-random-core:4.0.0'
 
     testImplementation 'org.mockito:mockito-core:3.6.0'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.2'

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/callback/AbstractValidatedCallback.java
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/callback/AbstractValidatedCallback.java
@@ -32,7 +32,7 @@ public abstract class AbstractValidatedCallback extends AbstractCallback {
      *
      * @return validation policies
      */
-    private JSONObject policies;
+    private String policies;
 
     /**
      * Return the list of failed policies for this callback.
@@ -51,7 +51,7 @@ public abstract class AbstractValidatedCallback extends AbstractCallback {
     protected void setAttribute(String name, Object value) {
         switch (name) {
             case "policies":
-                policies = ((JSONObject) value);
+                policies = value.toString();
                 break;
             case "failedPolicies":
                 prepareFailedPolicy((JSONArray) value);
@@ -64,6 +64,17 @@ public abstract class AbstractValidatedCallback extends AbstractCallback {
     }
 
     public abstract String getPrompt();
+
+    public JSONObject getPolicies() {
+        try {
+            if (policies != null) {
+                return new JSONObject(policies);
+            }
+            return null;
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     public void setValidateOnly(boolean validateOnly) {
         setValue(validateOnly, 1);

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/callback/AbstractValidatedCallback.java
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/callback/AbstractValidatedCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 - 2021 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/AuthTestSuite.java
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/AuthTestSuite.java
@@ -34,6 +34,7 @@ import org.junit.runners.Suite;
         NumberAttributeInputCallbackTest.class,
         SelectIdPCallbackTest.class,
         IdPCallbackTest.class,
+        SerializableTest.class,
 
 
         AuthServiceMockTest.class,

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/callback/SerializableTest.java
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/callback/SerializableTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 ForgeRock. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package org.forgerock.android.auth.callback;
+
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+import org.jeasy.random.api.Randomizer;
+import org.jeasy.random.randomizers.text.StringRandomizer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.util.Map;
+
+//Test to make sure all Callback class are serializable
+@RunWith(RobolectricTestRunner.class)
+public class SerializableTest {
+
+    @Test
+    public void testCallbackSerializable() throws IOException {
+        //We generate String for Object type.
+        EasyRandomParameters parameters = new EasyRandomParameters();
+        parameters.randomize(Object.class, new Randomizer<Object>() {
+            @Override
+            public Object getRandomValue() {
+                return new StringRandomizer().getRandomValue();
+            }
+        });
+        parameters.stringLengthRange(3, 3);
+        EasyRandom generator = new EasyRandom(parameters);
+        for (Map.Entry<String, Class<? extends Callback>> entry : CallbackFactory.getInstance().getCallbacks().entrySet()) {
+            Callback callback = generator.nextObject(entry.getValue());
+            convertToBytes(callback);
+        }
+    }
+
+    private byte[] convertToBytes(Object object) throws IOException {
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+             ObjectOutputStream out = new ObjectOutputStream(bos)) {
+            out.writeObject(object);
+            return bos.toByteArray();
+        }
+    }
+}


### PR DESCRIPTION
JSONObject defined under AbstractValidatedCallback is not serializable, classes ValidatedUsernameCallback, ValidatePasswordCallback, StringAttributeInputCallback, NumberAttributeInputCallback, BooleanAttributeInoutCallback cannot be serialized when passing the Node object from one Activity to another.