### PR TITLE
SDKS-1368 Provide Build-in Binary Protection to avoid Memory Corruption Attack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   
 #### Fixed
 - AbstractValidatedCallback is not serializable [SDKS-1486]
+- Provide Build-in Binary Protection to avoid Memory Corruption Attack [SDKS-1368]
 
 ## [3.1.2]
 #### Added

--- a/forgerock-auth/src/main/jni/Android.mk
+++ b/forgerock-auth/src/main/jni/Android.mk
@@ -10,5 +10,6 @@ include $(CLEAR_VARS)
 LOCAL_MODULE    := tool-file
 LOCAL_SRC_FILES := toolFile.cpp
 LOCAL_LDLIBS := -llog
+LOCAL_CFLAGS := -fstack-protector-all
 
 include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
SDKS-1368 Provide Build-in Binary Protection to avoid Memory Corruption Attack

Add -fstack-protector-all flag when compile native library for root detection.