### PR TITLE
NO-TICKET Add infrastructure for multiple loggers

### DIFF
--- a/forgerock-core/src/main/java/org/forgerock/android/auth/FRConsoleLogger.java
+++ b/forgerock-core/src/main/java/org/forgerock/android/auth/FRConsoleLogger.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022 ForgeRock. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package org.forgerock.android.auth;
+
+import android.util.Log;
+
+import org.forgerock.android.core.BuildConfig;
+
+/**
+ * {@link FRLogger} implemented with Android's default {@link Log} utility.
+ */
+class FRConsoleLogger implements FRLogger {
+
+    private static final String FORGE_ROCK = "ForgeRock";
+
+    @Override
+    public void error(String tag, Throwable t, String message, Object... values) {
+        log(Logger.Level.ERROR, tag, t, message, values);
+    }
+
+    @Override
+    public void error(String tag, String message, Object... values) {
+        log(Logger.Level.ERROR, tag, null, message, values);
+    }
+
+    @Override
+    public void warn(String tag, String message, Object... values) {
+        log(Logger.Level.WARN, tag, null, message, values);
+    }
+
+    @Override
+    public void warn(String tag, Throwable t, String message, Object... values) {
+        log(Logger.Level.WARN, tag, t, message, values);
+    }
+
+    @Override
+    public void debug(String tag, String message, Object... values) {
+        log(Logger.Level.DEBUG, tag, null, message, values);
+    }
+
+    private void log(Logger.Level level, String tag, Throwable t, String message, Object... args) {
+        final String value =
+                String.format("[%s] [%s]: ", BuildConfig.VERSION_NAME, tag)
+                        + String.format(message, args);
+
+        switch (level) {
+            case DEBUG:
+                Log.i(FORGE_ROCK, value);
+                break;
+            case WARN:
+                Log.w(FORGE_ROCK, value, t);
+                break;
+            case ERROR:
+                Log.e(FORGE_ROCK, value, t);
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/forgerock-core/src/main/java/org/forgerock/android/auth/FRLogger.java
+++ b/forgerock-core/src/main/java/org/forgerock/android/auth/FRLogger.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022 ForgeRock. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package org.forgerock.android.auth;
+
+/**
+ * General use logging interface that can be managed by {@link Logger}.
+ */
+public interface FRLogger {
+
+    void error(String tag, Throwable t, String message, Object... values);
+
+    void error(String tag, String message, Object... values);
+
+    void warn(String tag, String message, Object... values);
+
+    void warn(String tag, Throwable t, String message, Object... values);
+
+    void debug(String tag, String message, Object... values);
+}

--- a/forgerock-core/src/main/java/org/forgerock/android/auth/Logger.java
+++ b/forgerock-core/src/main/java/org/forgerock/android/auth/Logger.java
@@ -7,17 +7,15 @@
 
 package org.forgerock.android.auth;
 
-import android.util.Log;
-import androidx.annotation.VisibleForTesting;
-import org.forgerock.android.core.BuildConfig;
+import androidx.annotation.NonNull;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Logger for ForgeRock SDK
  */
 public class Logger {
-
-    @VisibleForTesting
-    static final String FORGE_ROCK = "ForgeRock";
 
     public enum Level {
         DEBUG,
@@ -29,6 +27,10 @@ public class Logger {
     //Default level to warn
     private static Level level = Level.WARN;
 
+    private static final Set<FRLogger> loggers = new HashSet<FRLogger>() {{
+        add(new FRConsoleLogger()); // Default logger, always present
+    }};
+
     public static void set(Level level) {
         Logger.level = level;
     }
@@ -37,41 +39,60 @@ public class Logger {
         return Logger.level == Level.DEBUG;
     }
 
-    private static void log(Level level, String tag, Throwable t, String message, Object... args) {
-        if (level.ordinal() >= Logger.level.ordinal() ) {
-            String value =
-                    String.format("[%s] [%s]: ", BuildConfig.VERSION_NAME, tag)
-                            + String.format(message, args);
-            switch (level) {
-                case DEBUG:
-                    Log.i(FORGE_ROCK, value);
-                    return;
-                case WARN:
-                    Log.w(FORGE_ROCK, value, t);
-                    return;
-                case ERROR:
-                    Log.e(FORGE_ROCK, value, t);
-            }
-        }
+    /**
+     * Add a logger to be handled by the system.
+     *
+     * @return {@code true} if the logger was not already added
+     */
+    public static boolean addLogger(@NonNull FRLogger logger) {
+        return loggers.add(logger);
+    }
+
+    /**
+     * Remove a logger from the system.
+     *
+     * @return {@code true} if the logger was added previously
+     */
+    public static boolean removeLogger(@NonNull FRLogger logger) {
+        return loggers.remove(logger);
     }
 
     public static void error(String tag, Throwable t, String message, Object... values) {
-        log(Level.ERROR, tag, t, message, values);
+        if (isLoggingDisabled(Level.ERROR)) return;
+        for (FRLogger logger : loggers) {
+            logger.error(tag, t, message, values);
+        }
     }
 
     public static void error(String tag, String message, Object... values) {
-        log(Level.ERROR, tag, null, message, values);
+        if (isLoggingDisabled(Level.ERROR)) return;
+        for (FRLogger logger : loggers) {
+            logger.error(tag, message, values);
+        }
     }
 
     public static void warn(String tag, String message, Object... values) {
-        log(Level.WARN, tag, null, message, values);
+        if (isLoggingDisabled(Level.WARN)) return;
+        for (FRLogger logger : loggers) {
+            logger.warn(tag, message, values);
+        }
     }
 
     public static void warn(String tag, Throwable t, String message, Object... values) {
-        log(Level.WARN, tag, t, message, values);
+        if (isLoggingDisabled(Level.WARN)) return;
+        for (FRLogger logger : loggers) {
+            logger.warn(tag, t, message, values);
+        }
     }
 
     public static void debug(String tag, String message, Object... values) {
-        log(Level.DEBUG, tag, null, message, values);
+        if (isLoggingDisabled(Level.DEBUG)) return;
+        for (FRLogger logger : loggers) {
+            logger.debug(tag, message, values);
+        }
+    }
+
+    private static boolean isLoggingDisabled(Level level) {
+        return level.ordinal() < Logger.level.ordinal();
     }
 }

--- a/forgerock-core/src/test/java/org/forgerock/android/auth/FRConsoleLoggerTest.java
+++ b/forgerock-core/src/test/java/org/forgerock/android/auth/FRConsoleLoggerTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2022 ForgeRock. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package org.forgerock.android.auth;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.util.Log;
+
+import org.forgerock.android.core.BuildConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.shadows.ShadowLog;
+
+@RunWith(RobolectricTestRunner.class)
+public class FRConsoleLoggerTest {
+
+    private final FRConsoleLogger logger = new FRConsoleLogger();
+
+    @Before
+    public void setUp() {
+        ShadowLog.stream = System.out;
+        ShadowLog.clear();
+    }
+
+    @Test
+    public void testDebugLogging() {
+        logger.debug("Test", "This is a test", null);
+        ShadowLog.LogItem logItem = ShadowLog.getLogs().get(0);
+        assertEquals(Log.INFO, logItem.type);
+        assertEquals("[" + BuildConfig.VERSION_NAME + "] [Test]: This is a test", logItem.msg);
+    }
+
+    @Test
+    public void testDebugLoggingWithArgs() {
+        logger.debug("Test", "This is a test %s, %d", "hello", 3);
+        ShadowLog.LogItem logItem = ShadowLog.getLogs().get(0);
+        assertEquals(Log.INFO, logItem.type);
+        assertEquals("[" + BuildConfig.VERSION_NAME + "] [Test]: This is a test hello, 3", logItem.msg);
+    }
+
+    @Test
+    public void testWarn() {
+        logger.warn("Test", "This is a test");
+        ShadowLog.LogItem logItem = ShadowLog.getLogs().get(0);
+        assertEquals(Log.WARN, logItem.type);
+        assertEquals("[" + BuildConfig.VERSION_NAME + "] [Test]: This is a test", logItem.msg);
+    }
+
+    @Test
+    public void testWarnWithArgs() {
+        logger.warn("Test", "This is a test %s, %d", "hello", 3);
+        ShadowLog.LogItem logItem = ShadowLog.getLogs().get(0);
+        assertEquals(Log.WARN, logItem.type);
+        assertEquals("[" + BuildConfig.VERSION_NAME + "] [Test]: This is a test hello, 3", logItem.msg);
+    }
+
+    @Test
+    public void testWarnThrowable() {
+        logger.warn("Test", new IllegalArgumentException("test"), "warning");
+        ShadowLog.LogItem logItem = ShadowLog.getLogs().get(0);
+        assertEquals(Log.WARN, logItem.type);
+        assertTrue(logItem.throwable instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void testError() {
+        logger.error("Test", "This is a test");
+        ShadowLog.LogItem logItem = ShadowLog.getLogs().get(0);
+        assertEquals(Log.ERROR, logItem.type);
+        assertEquals("[" + BuildConfig.VERSION_NAME + "] [Test]: This is a test", logItem.msg);
+    }
+
+    @Test
+    public void testErrorWithArgs() {
+        logger.error("Test", "This is a test %s, %d", "hello", 3);
+        ShadowLog.LogItem logItem = ShadowLog.getLogs().get(0);
+        assertEquals(Log.ERROR, logItem.type);
+        assertEquals("[" + BuildConfig.VERSION_NAME + "] [Test]: This is a test hello, 3", logItem.msg);
+    }
+
+    @Test
+    public void testErrorThrowable() {
+        logger.error("Test", new IllegalArgumentException("test"), "error");
+        ShadowLog.LogItem logItem = ShadowLog.getLogs().get(0);
+        assertEquals(Log.ERROR, logItem.type);
+        assertTrue(logItem.throwable instanceof IllegalArgumentException);
+    }
+}

--- a/forgerock-core/src/test/java/org/forgerock/android/auth/LoggerTest.java
+++ b/forgerock-core/src/test/java/org/forgerock/android/auth/LoggerTest.java
@@ -7,17 +7,15 @@
 
 package org.forgerock.android.auth;
 
-import android.util.Log;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import org.forgerock.android.core.BuildConfig;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.shadows.ShadowLog;
-import org.robolectric.shadows.ShadowLog.LogItem;
-
-import static org.junit.Assert.*;
 
 @RunWith(RobolectricTestRunner.class)
 public class LoggerTest {
@@ -30,29 +28,12 @@ public class LoggerTest {
     }
 
     @Test
-    public void testDebugLogging() {
-        Logger.debug("Test", "This is a test", null);
-        LogItem logItem = ShadowLog.getLogsForTag(Logger.FORGE_ROCK).get(0);
-        assertEquals(Log.INFO, logItem.type);
-        assertEquals("[" + BuildConfig.VERSION_NAME + "] [Test]: This is a test", logItem.msg);
-    }
-
-
-    @Test
-    public void testDebugLoggingWithArgs() {
-        Logger.debug("Test", "This is a test %s, %d", "hello", 3);
-        LogItem logItem = ShadowLog.getLogsForTag(Logger.FORGE_ROCK).get(0);
-        assertEquals(Log.INFO, logItem.type);
-        assertEquals("[" + BuildConfig.VERSION_NAME + "] [Test]: This is a test hello, 3", logItem.msg);
-    }
-
-    @Test
     public void testLowerLevel() {
         Logger.set(Logger.Level.ERROR);
         Logger.warn("Test", "warning");
         Logger.debug("Test", "debugging");
         //Should not log
-        assertEquals(0, ShadowLog.getLogsForTag(Logger.FORGE_ROCK).size());
+        assertEquals(0, ShadowLog.getLogs().size());
     }
 
     @Test
@@ -60,7 +41,7 @@ public class LoggerTest {
         Logger.set(Logger.Level.DEBUG);
         Logger.warn("Test", "warning");
         Logger.error("Test", "error");
-        assertEquals(2, ShadowLog.getLogsForTag(Logger.FORGE_ROCK).size());
+        assertEquals(2, ShadowLog.getLogs().size());
     }
 
     @Test
@@ -69,24 +50,7 @@ public class LoggerTest {
         Logger.debug("Test", "debugging");
         Logger.warn("Test", "warning");
         Logger.debug("Test", "debugging");
-        assertEquals(0, ShadowLog.getLogsForTag(Logger.FORGE_ROCK).size());
-    }
-
-
-    @Test
-    public void testWarnThrowable() {
-        Logger.warn("Test", new IllegalArgumentException("test"), "warning");
-        LogItem logItem = ShadowLog.getLogsForTag(Logger.FORGE_ROCK).get(0);
-        assertEquals(Log.WARN, logItem.type);
-        assertTrue(logItem.throwable instanceof IllegalArgumentException);
-    }
-
-    @Test
-    public void testErrorThrowable() {
-        Logger.error("Test", new IllegalArgumentException("test"), "error");
-        LogItem logItem = ShadowLog.getLogsForTag(Logger.FORGE_ROCK).get(0);
-        assertEquals(Log.ERROR, logItem.type);
-        assertTrue(logItem.throwable instanceof IllegalArgumentException);
+        assertEquals(0, ShadowLog.getLogs().size());
     }
 
     @Test


### PR DESCRIPTION
This commit adds the ability for the system to support multiple logger instances, while still
including the default Log utility that exists. This change will allow users of the SDK to
implement their own loggers and handle log messages as they see fit. As well, this mirrors the
capabilities of the iOS SDK.

This change is achieved by introducing an interface for those custom loggers (FRLogger),
implementing that interface with the Android Log class (FRConsoleLogger), and adding a set of
logger instances to the Logger class that can be added or removed (addLogger, removeLogger).
