### PR TITLE
SDKS-1737 Remove SHA1 Support for SSL Pinning

### DIFF
--- a/forgerock-auth/build.gradle
+++ b/forgerock-auth/build.gradle
@@ -21,21 +21,18 @@ android {
         minSdkVersion 21
         targetSdkVersion 31
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        manifestPlaceholders = [
+                'appAuthRedirectScheme': 'org.forgerock.demo'
+        ]
     }
 
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            manifestPlaceholders = [
-                    'appAuthRedirectScheme': 'org.forgerock.demo'
-            ]
         }
 
         debug {
-            manifestPlaceholders = [
-                    'appAuthRedirectScheme': 'org.forgerock.demo'
-            ]
         }
     }
 

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/ServerConfigTest.java
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/ServerConfigTest.java
@@ -79,46 +79,7 @@ public class ServerConfigTest {
         ServerConfig serverConfig = ServerConfig.builder()
                 .context(context)
                 .url("https://api.ipify.org")
-                .pin("sha256/9hNxmEFgLKGJXqgp61hyb8yIyiT9u0vgDZh4y8TmY/M=")
-                .build();
-
-        OkHttpClient client = OkHttpClientProvider.getInstance().lookup(serverConfig);
-
-        Request request = new Request.Builder()
-                .get()
-                .url("https://api.ipify.org?format=json")
-                .build();
-
-        CountDownLatch countDownLatch = new CountDownLatch(1);
-
-        final boolean[] result = new boolean[1];
-
-        client.newCall(request).enqueue(new okhttp3.Callback() {
-
-            @Override
-            public void onFailure(@NotNull Call call, @NotNull IOException e) {
-                result[0] = false;
-                countDownLatch.countDown();
-            }
-
-            @Override
-            public void onResponse(@NotNull Call call, @NotNull Response response) throws IOException {
-                result[0] = true;
-                countDownLatch.countDown();
-            }
-
-        });
-        countDownLatch.await();
-        assertTrue(result[0]);
-
-    }
-
-    @Test
-    public void testSha1Pinning() throws InterruptedException {
-        ServerConfig serverConfig = ServerConfig.builder()
-                .context(context)
-                .url("https://api.ipify.org")
-                .pin("sha1/2vB3hhEJ98C5efhhWpxtD2wxYek=")
+                .pin("9hNxmEFgLKGJXqgp61hyb8yIyiT9u0vgDZh4y8TmY/M=")
                 .build();
 
         OkHttpClient client = OkHttpClientProvider.getInstance().lookup(serverConfig);
@@ -160,8 +121,8 @@ public class ServerConfigTest {
         ServerConfig serverConfig = ServerConfig.builder()
                 .context(context)
                 .url("https://api.ipify.org")
-                .pin("sha256/9hNxmEFgLKGJXqgp61hyb8yIyiT9u0vgDZh4y8TmY/M=")
-                .pin("sha256/invalid")
+                .pin("9hNxmEFgLKGJXqgp61hyb8yIyiT9u0vgDZh4y8TmY/M=")
+                .pin("invalid")
                 .build();
 
         OkHttpClient client = OkHttpClientProvider.getInstance().lookup(serverConfig);
@@ -200,7 +161,7 @@ public class ServerConfigTest {
         ServerConfig serverConfig = ServerConfig.builder()
                 .context(context)
                 .url("https://api.ipify.org")
-                .pin("sha256/invalid=")
+                .pin("invalid=")
                 .build();
 
         OkHttpClient client = OkHttpClientProvider.getInstance().lookup(serverConfig);
@@ -243,9 +204,7 @@ public class ServerConfigTest {
         OkHttpClient client = OkHttpClientProvider.getInstance().lookup(serverConfig);
         assertThat(client.certificatePinner().getPins())
                 .contains(new CertificatePinner.Pin(serverConfig.getHost(),
-                        "sha256/9hNxmEFgLKGJXqgp61hyb8yIyiT9u0vgDZh4y8TmY/M="))
-                .contains(new CertificatePinner.Pin(serverConfig.getHost(),
-                        "sha1/2vB3hhEJ98C5efhhWpxtD2wxYek="));
+                        "sha256/9hNxmEFgLKGJXqgp61hyb8yIyiT9u0vgDZh4y8TmY/M="));
     }
 
     @Test

--- a/forgerock-auth/src/test/res/values/strings.xml
+++ b/forgerock-auth/src/test/res/values/strings.xml
@@ -23,8 +23,7 @@
     <bool name="forgerock_enable_cookie" translatable="false">true</bool>
     <string name="forgerock_cookie_name" translatable="false">iPlanetDirectoryPro</string>
     <string-array name="forgerock_ssl_pinning_public_key_hashes">
-        <item>sha256/9hNxmEFgLKGJXqgp61hyb8yIyiT9u0vgDZh4y8TmY/M=</item>
-        <item>sha1/2vB3hhEJ98C5efhhWpxtD2wxYek=</item>
+        <item>9hNxmEFgLKGJXqgp61hyb8yIyiT9u0vgDZh4y8TmY/M=</item>
     </string-array>
 
 

--- a/forgerock-core/src/main/java/org/forgerock/android/auth/OkHttpClientProvider.java
+++ b/forgerock-core/src/main/java/org/forgerock/android/auth/OkHttpClientProvider.java
@@ -74,7 +74,7 @@ class OkHttpClientProvider {
         if (!networkConfig.getPins().isEmpty()) {
             CertificatePinner.Builder cpBuilder = new CertificatePinner.Builder();
             for (String s : networkConfig.getPins()) {
-                cpBuilder.add(networkConfig.getHost(), s);
+                cpBuilder.add(networkConfig.getHost(), "sha256/" + s);
             }
             builder.certificatePinner(cpBuilder.build());
         }

--- a/forgerock-core/src/test/java/org/forgerock/android/auth/NetworkConfigTest.java
+++ b/forgerock-core/src/test/java/org/forgerock/android/auth/NetworkConfigTest.java
@@ -78,15 +78,13 @@ public class NetworkConfigTest {
     public void testPinningConfig() {
         NetworkConfig networkConfig = NetworkConfig.networkBuilder()
                 .host(server.getHostName())
-                .pin("sha256/9hNxmEFgLKGJXqgp61hyb8yIyiT9u0vgDZh4y8TmY/M=")
-                .pin("sha1/2vB3hhEJ98C5efhhWpxtD2wxYek=")
+                .pin("9hNxmEFgLKGJXqgp61hyb8yIyiT9u0vgDZh4y8TmY/M=")
                 .build();
         OkHttpClient client = OkHttpClientProvider.getInstance().lookup(networkConfig);
         //Make sure the pinning is configured
         Assertions.assertThat(client.certificatePinner().getPins())
                 .contains(new CertificatePinner.Pin(server.getHostName(),
-                        "sha256/9hNxmEFgLKGJXqgp61hyb8yIyiT9u0vgDZh4y8TmY/M="))
-                .contains(new CertificatePinner.Pin(server.getHostName(), "sha1/2vB3hhEJ98C5efhhWpxtD2wxYek="));
+                        "sha256/9hNxmEFgLKGJXqgp61hyb8yIyiT9u0vgDZh4y8TmY/M="));
     }
 
 


### PR DESCRIPTION
Align with iOS, now Android only support SHA256 SSL Pinning