### PR TITLE
SDKS-1409 Registration of a second mechanism should overwrite attributes of existing account to align with iOS

### DIFF
--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/OathFactoryTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/OathFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2022 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -21,6 +21,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
@@ -403,6 +405,8 @@ public class OathFactoryTest extends FRABaseTest {
         StorageClient storageClient = mock(DefaultStorageClient.class);
         given(storageClient.getAccount(any(String.class))).willReturn( null);
         given(storageClient.setAccount(any(Account.class))).willReturn(false);
+        given(storageClient.getMechanismsForAccount(any(Account.class))).willReturn(Collections.emptyList());
+        given(storageClient.setMechanism(any(Mechanism.class))).willReturn(true);
         factory = new OathFactory(context, storageClient);
 
         try {
@@ -411,7 +415,7 @@ public class OathFactoryTest extends FRABaseTest {
             Assert.fail("Should throw MechanismCreationException");
         } catch (Exception e) {
             assertTrue(e.getCause() instanceof MechanismCreationException);
-            assertTrue(e.getLocalizedMessage().contains("Error while storing a new Account"));
+            assertTrue(e.getLocalizedMessage().contains("Error while storing the Account"));
         }
     }
 

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/PushFactoryTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/PushFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2022 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -22,6 +22,7 @@ import org.robolectric.RobolectricTestRunner;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.Collections;
 
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -197,7 +198,10 @@ public class PushFactoryTest extends FRABaseTest {
         StorageClient storageClient = mock(DefaultStorageClient.class);
         given(storageClient.getAccount(any(String.class))).willReturn( null);
         given(storageClient.setAccount(any(Account.class))).willReturn(false);
-        factory = new PushFactory(context, storageClient, "s-o-m-e-i-d");
+        given(storageClient.getMechanismsForAccount(any(Account.class))).willReturn(Collections.emptyList());
+        given(storageClient.setMechanism(any(Mechanism.class))).willReturn(true);
+        factory = spy(new PushFactory(context, storageClient, "s-o-m-e-i-d"));
+        doReturn(true).when(factory).checkGooglePlayServices();
 
         try {
             factory.createFromUri(uri, pushListenerFuture);
@@ -205,7 +209,7 @@ public class PushFactoryTest extends FRABaseTest {
             Assert.fail("Should throw MechanismCreationException");
         } catch (Exception e) {
             assertTrue(e.getCause() instanceof MechanismCreationException);
-            assertTrue(e.getLocalizedMessage().contains("Error while storing a new Account"));
+            assertTrue(e.getLocalizedMessage().contains("Error while storing the Account"));
         }
     }
 


### PR DESCRIPTION
# JIRA Ticket

[SDKS-1409](https://bugster.forgerock.org/jira/browse/SDKS-1409) Discrepancy between iOS and Android :: account logo for combined PUSH and OATH accounts

# Description

While registering a second mechanism iOS and Android are behaving differently. Android is keeping the existing Account attributes, while iOS is overwriting existing attributes. We are changing Android to align with iOS.

# Definition of Done Checklist:

- [x] Acceptance criteria is met.
- [x] All tasks listed in the user story have been completed.
- [x] Coded to standards.
- [x] Ensure backward compatibility.
- [x] API reference docs is updated.
- [x] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] Functional spec is written/updated.
- [ ] contains example code snippets.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).