### PR TITLE
SDKS-1408 Discrepancies between Android and iOS behavior upon registering OATH account (Issuer param)

### DIFF
--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/MechanismParser.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/MechanismParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2022 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -93,6 +93,9 @@ abstract class MechanismParser {
         for (String query : queryParts) {
             String[] split = split(query, "=");
             if (split != null) {
+                if (split[0].equals(ISSUER) && split[1].isEmpty()) {
+                    continue;
+                }
                 r.put(split[0], split[1]);
             }
         }

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/OathParserTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/OathParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2022 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -61,6 +61,13 @@ public class OathParserTest {
     }
 
     @Test
+    public void testShouldParseIssuerSinglePath() throws MechanismParsingException {
+        Map<String, String> result = oathParser.map("otpauth://totp/Badger?secret=ABC");
+        assertEquals(result.get(OathParser.ISSUER), "Badger");
+        assertEquals(result.get(OathParser.ACCOUNT_NAME), "Badger");
+    }
+
+    @Test
     public void testShouldParseIssuerFromParameters() throws MechanismParsingException {
         Map<String, String> result = oathParser.map("otpauth://totp/?issuer=Stoat&secret=ABC");
         assertEquals(result.get(OathParser.ISSUER), "Stoat");
@@ -71,6 +78,13 @@ public class OathParserTest {
     public void testShouldOverwriteIssuerFromParameters() throws MechanismParsingException {
         Map<String, String> result = oathParser.map("otpauth://totp/Badger:ferret?issuer=Stoat&secret=ABC");
         assertEquals(result.get(OathParser.ISSUER), "Stoat");
+        assertEquals(result.get(OathParser.ACCOUNT_NAME), "ferret");
+    }
+
+    @Test
+    public void testShouldKeepIssuerFromPathIfParameterIsEmpty() throws MechanismParsingException {
+        Map<String, String> result = oathParser.map("otpauth://totp/Badger:ferret?issuer=&secret=ABC");
+        assertEquals(result.get(OathParser.ISSUER), "Badger");
         assertEquals(result.get(OathParser.ACCOUNT_NAME), "ferret");
     }
 


### PR DESCRIPTION
# JIRA Ticket

[SDKS-1408](https://bugster.forgerock.org/jira/browse/SDKS-1408) Discrepancies between Android and iOS behavior upon registering OATH account (Issuer param)

# Description

While registering a new mechanism, if "issuer" is empty on the query parameter of the URI, but available in the path, the SDK should not throw exception. Instead, it should use the issue in the path.

# Definition of Done Checklist:

- [x] Acceptance criteria is met.
- [x] All tasks listed in the user story have been completed.
- [x] Coded to standards.
- [x] Ensure backward compatibility.
- [x] API reference docs is updated.
- [x] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] Functional spec is written/updated.
- [ ] contains example code snippets.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).