### PR TITLE
SDKS-2066 DefaultTokenManager does not cache the access token upon retrieval from local storage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 #### Fixed
 - Changed Activity type used as parameter in 'PushNotification.accept' [SDKS-1968]
 - Deserializing an object with whitelist to prevent deserialization of untrusted data.  [SDKS-1818]
+- DefaultTokenManager does not cache AccessToken in memory upon retrieval from Shared Preferences.  [SDKS-2066]
 
 
 ## [3.3.3]

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/DefaultTokenManager.java
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/DefaultTokenManager.java
@@ -215,7 +215,9 @@ class DefaultTokenManager implements TokenManager {
         if (value == null) {
             return null;
         }
-        return AccessToken.fromJson(value);
+        AccessToken accessToken =  AccessToken.fromJson(value);
+        cache(accessToken);
+        return accessToken;
     }
 
     /**

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/DefaultTokenManagerTest.java
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/DefaultTokenManagerTest.java
@@ -113,6 +113,16 @@ public class DefaultTokenManagerTest extends BaseTest {
 
         //If reference are equal, they come from the cache
         assertSame(storedAccessToken1, storedAccessToken2);
+
+        //Let the cache expired
+        Thread.sleep(100L);
+        AccessToken storedAccessToken3 = getAccessToken(tokenManager);
+        //The cache is expired, should re-cache and token should not have the same references
+        assertNotSame(storedAccessToken1, storedAccessToken3);
+
+        //Confirm that the token is re-cached
+        AccessToken storedAccessToken4 = getAccessToken(tokenManager);
+        assertSame(storedAccessToken3, storedAccessToken4);
     }
 
     @Test


### PR DESCRIPTION

# JIRA Ticket

[SDKS-2066](https://bugster.forgerock.org/jira/browse/SDKS-2066)

# Description

Cache the access token after retrieval from local storage, to enable the cache forgerock_oauth_cache needs to set to a value > 0.

# Definition of Done Checklist:

- [X] Acceptance criteria is met.
- [X] All tasks listed in the user story have been completed.
- [X] Coded to standards.
- [X] Ensure backward compatibility.
- [X] API reference docs is updated.
- [X] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] Functional spec is written/updated.
- [ ] contains example code snippets.
- [X] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).