### PR TITLE
Automate Cloud Upgrade Testing [SDKS-1789]

### DIFF
--- a/.github/workflows/run-live-tests.yaml
+++ b/.github/workflows/run-live-tests.yaml
@@ -1,0 +1,102 @@
+name: Run Live Tests
+on:
+  workflow_dispatch:
+    inputs:
+      am-url:
+        description: The AM url to run live test cases against
+        type: string
+        required: true
+        default: https://openam-forgerrock-sdksteanant.forgeblocks.com/am
+      realm:
+        description: The AM realm to use
+        type: string
+        required: true
+        default: alpha
+      cookie-name:
+        description: The AM session cookie name
+        type: string
+        required: true
+        default: iPlanetDirectoryPro
+  
+jobs:
+  run-tests:
+    runs-on: macos-latest
+
+    steps:
+      # Clone the repo
+      - name: Clone the repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          fetch-depth: 0
+
+      # Setup JDK and cache and restore dependencies.
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+          cache: 'gradle'
+
+      # Replace forgerock_url, forgerock_realm, and forgerock_cookie_name values in strings.xml
+      - name: Configure strings.xml
+        run: |
+          amURL=$(echo ${{ inputs.am-url }} | sed 's/\//\\\//g')
+          echo $amURL
+          sed -i -r "s/\(<string name=\"forgerock_url\".*>\).*\(<\/string>\)/\1$amURL\2/" "forgerock-auth/src/androidTest/res/values/strings.xml"
+          sed -i -r "s/\(<string name=\"forgerock_realm\".*>\).*\(<\/string>\)/\1${{ inputs.realm }}\2/" "forgerock-auth/src/androidTest/res/values/strings.xml"
+          sed -i -r "s/\(<string name=\"forgerock_cookie_name\".*>\).*\(<\/string>\)/\1${{ inputs.cookie-name }}\2/" "forgerock-auth/src/androidTest/res/values/strings.xml"
+          rm -rf forgerock-auth/src/androidTest/res/values/strings.xml-r
+          cat forgerock-auth/src/androidTest/res/values/strings.xml
+
+      # Prepare test emulator
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 29
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: echo "Generated AVD snapshot for caching."
+
+      # Run the e2e tests on emulator
+      - name: Run e2e tests on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 29
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: ./gradlew -Pandroid.testInstrumentationRunnerArguments.package=org.forgerock.android.auth.callback :forgerock-auth:connectedAndroidTest --stacktrace --no-daemon
+
+      # Publish test reports
+      - name: Publish test results
+        if: success() || failure()
+        uses: dorny/test-reporter@v1
+        with:
+          name: e2e tests results
+          path: 'forgerock-auth/build/outputs/androidTest-results/connected/TEST-*.xml'
+          list-suites: 'all'
+          list-tests: 'all'
+          fail-on-error: 'true'
+          reporter: java-junit
+
+      # Save the logcat logs as run artifact
+      - name: Upload logcat logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: Logcat-logs
+          path: forgerock-auth/build/outputs/androidTest-results/connected/**/logcat-org*.txt
+      
+      # Send slack notification with result status
+      - uses: 8398a7/action-slack@v3
+        with:
+          mention: 'stoyan.petrov'
+          if_mention: 'failure,cancelled'
+          fields: repo,author,eventName,message,job,took
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        if: always()


### PR DESCRIPTION
# JIRA Ticket

[SDKS-1789](https://bugster.forgerock.org/jira/browse/SDKS-1789) "Automate Cloud Upgrade Testing"

# Description

This PR adds workflow for triggering the e2e test cases against live IDCloud environment. The workflow is called "Run Live Tests".
The e2e tests now can be triggered either manually from the "Actions" menu in the repo, or via an HTTP request. 
Triggering the workflow via HTTP request requires a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) (PAT) passed as a Bearer token in the Authorization header. For more details read the [workflow-dispatch-event](https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event) docs.