### PR TITLE
ForgeRock Android SDK 3.4.0 release preparation (fix release version)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [3.3.4]
+## [3.4.0]
 #### Added
 - Dynamic SDK Configuration [SDKS-1759]
 - Android 13 support. [SDKS-1944]

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,5 +24,5 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 GROUP=org.forgerock
-VERSION=3.3.4
+VERSION=3.4.0
 VERSION_CODE=13


### PR DESCRIPTION
# JIRA Ticket

[SDKS-2103](https://bugster.forgerock.org/jira/browse/SDKS-2103) "ForgeRock Android SDK 3.4.0 Release"
Fix release version to **3.4.0**