### PR TITLE
SDKS-2091 Remove Keys after the binding process is failed

### DIFF
--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/callback/DeviceSigningVerifierCallback.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/callback/DeviceSigningVerifierCallback.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 ForgeRock. All rights reserved.
+ * Copyright (c) 2022 - 2023 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -198,10 +198,6 @@ open class DeviceSigningVerifierCallback : AbstractCallback, Binding {
                     }
                 }
             }
-        } catch (e: TimeoutCancellationException) {
-            handleException(Timeout(), e)
-        } catch (e: OperationCanceledException) {
-            handleException(Abort(), e)
         } catch (e: Exception) {
             // This Exception happens only when there is Signing or keypair failed.
             handleException(e)

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/devicebind/ApplicationPinDeviceAuthenticator.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/devicebind/ApplicationPinDeviceAuthenticator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 ForgeRock. All rights reserved.
+ * Copyright (c) 2022 - 2023 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -18,13 +18,13 @@ import org.forgerock.android.auth.CryptoKey
 import org.forgerock.android.auth.EncryptedFileKeyStore
 import org.forgerock.android.auth.InitProvider
 import org.forgerock.android.auth.KeyStoreRepository
+import org.forgerock.android.auth.Logger
 import org.forgerock.android.auth.callback.DeviceBindingAuthenticationType
 import org.forgerock.android.auth.devicebind.DeviceBindingErrorStatus.*
 import java.io.FileNotFoundException
 import java.io.InputStream
 import java.io.OutputStream
 import java.security.KeyStore
-import java.security.PrivateKey
 import java.security.UnrecoverableKeyException
 import java.security.interfaces.RSAPublicKey
 import java.util.*
@@ -32,6 +32,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
+private val TAG = ApplicationPinDeviceAuthenticator::class.java.simpleName
 /**
  * Device Authenticator which use Application PIN to secure device cryptography keys
  */
@@ -129,6 +130,14 @@ open class ApplicationPinDeviceAuthenticator : CryptoAware, DeviceAuthenticator,
 
     final override fun type(): DeviceBindingAuthenticationType =
         DeviceBindingAuthenticationType.APPLICATION_PIN
+
+    override fun deleteKeys(context: Context) {
+        try {
+            keyStore.delete(context)
+        } catch (e: Exception) {
+            Logger.warn(TAG, e, e.message)
+        }
+    }
 
     override fun getInputStream(context: Context): InputStream {
         return keyStore.getInputStream(context)

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/devicebind/DeviceBindAuthenticators.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/devicebind/DeviceBindAuthenticators.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 ForgeRock. All rights reserved.
+ * Copyright (c) 2022 - 2023 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -43,6 +43,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
 import org.forgerock.android.auth.CryptoKey
+import org.forgerock.android.auth.Logger
 import org.forgerock.android.auth.callback.DeviceBindingAuthenticationType
 import java.security.PrivateKey
 import java.security.interfaces.RSAPublicKey
@@ -50,6 +51,7 @@ import java.util.*
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
+private val TAG = DeviceAuthenticator::class.java.simpleName
 /**
  * Device Authenticator Interface
  */
@@ -116,6 +118,8 @@ interface DeviceAuthenticator {
 
     fun type(): DeviceBindingAuthenticationType
 
+    fun deleteKeys(context: Context)
+
 }
 
 fun DeviceAuthenticator.initialize(userId: String, prompt: Prompt) {
@@ -159,6 +163,14 @@ abstract class BiometricAuthenticator : CryptoAware, DeviceAuthenticator {
 
     fun setBiometricHandler(biometricHandler: BiometricHandler) {
         this.biometricInterface = biometricHandler
+    }
+
+    override fun deleteKeys(context: Context) {
+        try {
+            cryptoKey.deleteKeys()
+        } catch (e: Exception) {
+            Logger.warn(TAG, e, e.message)
+        }
     }
 
     /**
@@ -307,6 +319,14 @@ open class None : CryptoAware, DeviceAuthenticator {
      * Default is true for None type
      */
     override fun isSupported(context: Context): Boolean = true
+
+    override fun deleteKeys(context: Context) {
+        try {
+            cryptoKey.deleteKeys()
+        } catch (e: Exception) {
+            Logger.warn(TAG, e, e.message)
+        }
+    }
 
     final override fun type(): DeviceBindingAuthenticationType =
         DeviceBindingAuthenticationType.NONE

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/devicebind/DeviceBindingStatus.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/devicebind/DeviceBindingStatus.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 ForgeRock. All rights reserved.
+ * Copyright (c) 2022 - 2023 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -60,7 +60,7 @@ data class Success(val privateKey: PrivateKey) : DeviceBindingStatus
  * Exceptions for device binding
  */
 class DeviceBindingException : Exception {
-    internal val status: DeviceBindingErrorStatus
+    val status: DeviceBindingErrorStatus
 
     constructor(status: DeviceBindingErrorStatus) : super(status.message) {
         this.status = status

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/devicebind/SharedPreferencesDeviceRepository.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/devicebind/SharedPreferencesDeviceRepository.kt
@@ -27,6 +27,9 @@ interface DeviceRepository {
                 authenticationType: DeviceBindingAuthenticationType): String
 
     fun getAllKeys(): MutableMap<String, *>?
+
+    fun delete(key: String)
+
 }
 
 const val userIdKey = "userId"
@@ -64,6 +67,10 @@ internal class SharedPreferencesDeviceRepository(context: Context,
 
     override fun getAllKeys(): MutableMap<String, *>? {
         return sharedPreferences.all
+    }
+
+    override fun delete(key: String) {
+        sharedPreferences.edit().remove(key).apply()
     }
 }
 

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/devicebind/ApplicationPinDeviceAuthenticatorTest.kt
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/devicebind/ApplicationPinDeviceAuthenticatorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 ForgeRock. All rights reserved.
+ * Copyright (c) 2022 - 2023 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -11,6 +11,7 @@ import android.os.OperationCanceledException
 import androidx.fragment.app.FragmentActivity
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.forgerock.android.auth.AppPinAuthenticator
@@ -62,7 +63,7 @@ class ApplicationPinDeviceAuthenticatorTest {
         //Test pin is cached for 1 sec
         assertThat(authenticator.size()).isGreaterThan(1000)
         assertThat(authenticator.pinRef.get()).isNotNull()
-        authenticator.worker.awaitTermination(3, TimeUnit.SECONDS)
+        delay(3000)
         assertThat(authenticator.pinRef.get()).isNull()
     }
 
@@ -176,6 +177,10 @@ class ApplicationPinDeviceAuthenticatorTest {
         }
 
         override fun delete(context: Context) {
+            byteArrayOutputStream = ByteArrayOutputStream(1024)
+        }
+
+        override fun deleteKeys(context: Context) {
             byteArrayOutputStream = ByteArrayOutputStream(1024)
         }
 

--- a/forgerock-core/src/main/java/org/forgerock/android/auth/AppPinAuthenticator.kt
+++ b/forgerock-core/src/main/java/org/forgerock/android/auth/AppPinAuthenticator.kt
@@ -27,6 +27,7 @@ import java.security.KeyStore
 import java.security.UnrecoverableKeyException
 import java.security.spec.RSAKeyGenParameterSpec
 
+private val TAG = AppPinAuthenticator::class.java.simpleName
 /**
  * An authenticator to authenticate the user with Application Pin
  */
@@ -72,6 +73,7 @@ class AppPinAuthenticator(private val cryptoKey: CryptoKey,
         try {
             keyStore = getKeyStore(context)
         } catch (e: Exception) {
+            Logger.warn(TAG, e, "Failed to load Keystore.")
             return false
         }
         return keyStore.containsAlias(getKeyAlias())

--- a/forgerock-core/src/main/java/org/forgerock/android/auth/CryptoKey.kt
+++ b/forgerock-core/src/main/java/org/forgerock/android/auth/CryptoKey.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 ForgeRock. All rights reserved.
+ * Copyright (c) 2022 - 2023 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -67,6 +67,14 @@ class CryptoKey(private var keyId: String) {
     fun getPrivateKey(): PrivateKey? {
         val keyStore: KeyStore = getKeyStore()
         return keyStore.getKey(keyAlias, null) as? PrivateKey
+    }
+
+    /**
+     * Delete keys from Android KeyStore
+     */
+    fun deleteKeys() {
+        val keyStore: KeyStore = getKeyStore()
+        keyStore.deleteEntry(keyAlias)
     }
 
     /**


### PR DESCRIPTION
# JIRA Ticket

SDKS-2091

# Description

SDKS-2091 Remove Keys after the binding process is failed
When the binding process is triggered, it generates new keys and replaces existing keys, after authentication failed, the newly generated keys are left behind in the device. During the process of Device Signing Verification, since there is a generated keys, it triggered the authentication process, but the keys do not match with the server, and make the signing process failed. To resolve this, when authentication failed, it removes the keys, and the user is required to perform rebinding again.

# Definition of Done Checklist:

- [ ] Acceptance criteria is met.
- [ ] All tasks listed in the user story have been completed.
- [ ] Coded to standards.
- [ ] Ensure backward compatibility.
- [ ] API reference docs is updated.
- [ ] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] Functional spec is written/updated.
- [ ] contains example code snippets.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).