### PR TITLE
SDKS-2238  Google Play Services is incompatible with the latest version of Location Service, rollback to version 20.0.0

### DIFF
--- a/forgerock-auth/build.gradle
+++ b/forgerock-auth/build.gradle
@@ -97,7 +97,8 @@ dependencies {
     implementation 'androidx.fragment:fragment-ktx:1.5.4'
 
     //Make it optional for developer
-    compileOnly 'com.google.android.gms:play-services-location:21.0.1'
+    //There is an issue for later version of location services https://github.com/mapbox/mapbox-maps-android/issues/1752
+    compileOnly 'com.google.android.gms:play-services-location:20.0.0'
     compileOnly 'com.google.android.gms:play-services-safetynet:18.0.1'
     compileOnly 'net.openid:appauth:0.7.1'
     compileOnly 'com.google.android.gms:play-services-fido:19.0.0'
@@ -118,7 +119,7 @@ dependencies {
     androidTestImplementation 'com.squareup.okhttp:mockwebserver:2.7.5'
     androidTestImplementation 'commons-io:commons-io:2.6'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
-    androidTestImplementation 'com.google.android.gms:play-services-location:21.0.1'
+    androidTestImplementation 'com.google.android.gms:play-services-location:20.0.0'
     //Do not update to the latest library, Only 2.x compatible with Android M and below.
     androidTestImplementation 'org.assertj:assertj-core:2.9.1'
     androidTestImplementation 'com.google.android.gms:play-services-fido:19.0.0'


### PR DESCRIPTION
…

# JIRA Ticket

https://bugster.forgerock.org/jira/browse/SDKS-2328

# Description

SDKS-2328  Google Play Services is incompatible with the latest version of Location Service, rollback to version 20.0.0


# Definition of Done Checklist:

- [ ] Acceptance criteria is met.
- [ ] All tasks listed in the user story have been completed.
- [ ] Coded to standards.
- [ ] Ensure backward compatibility.
- [ ] API reference docs is updated.
- [ ] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] Functional spec is written/updated.
- [ ] contains example code snippets.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).