### PR TITLE
SDKS-2334 - Add BackStage Docs theme to HTML and JavaDoc outputs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,22 @@ Documentation for the SDKs is provided at **<https://sdks.forgerock.com>**, and 
 
 * Introducing the SDK Features
 * Preparing AM for use with the SDKS
-* API Reference documentation
+
+### Build API Reference Documentation
+
+You can build the API reference documentation, which uses Dokka to generate either Javadoc or HTML output.
+
+HTML
+: `./gradlew clean dokkaHtmlMultiModule` 
+: View the output at [`build/api-reference/html/`](build/api-reference/html/index.html).
+
+JavaDoc
+: `./gradlew clean dokkaJavadocCollector`
+: View the output at [`build/api-reference/javadoc/`](build/api-reference/javadoc/index.html).
+
+> **TIP**: Use the following command to build both HTML and JavaDoc: 
+> 
+>`./gradlew clean dokkaHtmlMultiModule dokkaJavadocCollector`
 
 <!------------------------------------------------------------------------------------------------------------------------------------>
 <!-- SUPPORT -->

--- a/build.gradle
+++ b/build.gradle
@@ -8,10 +8,15 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.7.20'
+    ext {
+        kotlin_version = '1.7.20'
+        customCSSFile = projectDir.toString() + "/dokka/fr-backstage-styles.css"
+        customLogoFile = projectDir.toString() + "/dokka/logo-icon.svg"
+        customTemplatesFolder = file(projectDir.toString() + "/dokka/templates")
+    }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -21,7 +26,7 @@ buildscript {
         classpath "com.adarshr:gradle-test-logger-plugin:2.0.0"
         classpath 'com.google.gms:google-services:4.3.5'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.jetbrains.dokka:dokka-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.7.20"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -31,16 +36,66 @@ buildscript {
 plugins {
     id('io.github.gradle-nexus.publish-plugin') version '1.1.0'
     id('org.sonatype.gradle.plugins.scan') version '2.4.0'
-    id("org.jetbrains.dokka") version "1.7.20"
 }
+
+apply plugin: "org.jetbrains.dokka"
 
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
 }
+
+subprojects {
+    apply plugin: "org.jetbrains.dokka"
+
+    tasks.named("dokkaHtml") {
+        pluginsMapConfiguration.set(
+            [
+                "org.jetbrains.dokka.base.DokkaBase": """{
+                    "customStyleSheets": ["$customCSSFile"],
+                    "templatesDir": "$customTemplatesFolder"   
+                }"""
+            ]
+        )
+    }
+
+    tasks.named("dokkaHtmlPartial") {
+        pluginsMapConfiguration.set(
+            [
+                "org.jetbrains.dokka.base.DokkaBase": """{
+                    "customStyleSheets": ["$customCSSFile"],
+                    "templatesDir": "$customTemplatesFolder"   
+                }"""
+            ]
+        )
+    }
+}
+
+afterEvaluate {
+    tasks.named("dokkaHtmlMultiModule") {
+        moduleName.set("ForgeRock SDK for Android")
+        moduleVersion.set(project.property('VERSION'))
+        outputDirectory.set(file("build/api-reference/html"))
+        pluginsMapConfiguration.set(
+            [
+                "org.jetbrains.dokka.base.DokkaBase": """{
+                    "customStyleSheets": ["$customCSSFile"],
+                    "customAssets": ["$customLogoFile"],
+                    "templatesDir": "$customTemplatesFolder"
+                }"""
+            ]
+        )
+    }
+    tasks.named("dokkaJavadocCollector") {
+        moduleName.set("ForgeRock SDK for Android Javadoc")
+        moduleVersion.set(project.property('VERSION'))
+        outputDirectory.set(file("build/api-reference/javadoc"))
+    }
+
+}
+
 
 ossIndexAudit {
     username = System.properties['username']
@@ -68,8 +123,4 @@ if (secretPropsFile.exists()) {
     p.each { name, value ->
         ext[name] = value
     }
-}
-
-tasks.dokkaHtmlMultiModule.configure {
-    outputDirectory.set(file("build/dokka/html/$rootProject.name"))
 }

--- a/config/kdoc.gradle
+++ b/config/kdoc.gradle
@@ -32,16 +32,18 @@ dokkaHtml.dependsOn delombok
 dokkaJavadoc {
     dokkaSourceSets {
         named("main") {
-            // Main source set conf
+            displayName.set(name)
             outputDirectory = file("build/javadoc/$project.name-dokka")
             sourceDirs = files("$buildDir/src-delomboked")
             sourceRoots.setFrom(file("$buildDir/src-delomboked"))
-            noAndroidSdkLink.set(false)
-            includeNonPublic.set(true)
+            reportUndocumented.set(false)
             skipEmptyPackages.set(true)
-            reportUndocumented.set(true)
             skipDeprecated.set(false)
-
+            suppressGeneratedFiles.set(true)
+            noStdlibLink.set(false)
+            noJdkLink.set(false)
+            noAndroidSdkLink.set(false)
+            suppress.set(false)
         }
     }
 }
@@ -49,7 +51,6 @@ dokkaJavadoc {
 dokkaHtml {
     dokkaSourceSets {
         named("main") {
-            // Main source set conf
             outputDirectory = file("build/html/$project.name-dokka")
             sourceDirs = files("$buildDir/src-delomboked")
             sourceRoots.setFrom(file("$buildDir/src-delomboked"))

--- a/dokka/fr-backstage-styles.css
+++ b/dokka/fr-backstage-styles.css
@@ -1,0 +1,146 @@
+:root {
+  --forgerock-dark-blue: #032B75;
+  --forgerock-light-blue: #006AC8;
+  --forgerock-green: #00BB86;
+  --forgerock-light-yellow: #F9E486;
+  --forgerock-yellow: #F99900;
+  --forgerock-orange: #F96700;
+  --forgerock-red: #CC0937;
+  --forgerock-violet: #732F9D;
+  --forgerock-dark-grey: #505151;
+  --backstage-site-footer-position: relative;
+  --top-navigation-height: 50px;
+  --sidemenu-section-active-color: #F96700;
+  --default-font-family: "Open Sans", sans-serif;
+  --default-font-size: 16px;
+  --active-tab-border-color: --forgerock-dark-blue;
+  --active-section-color: --forgerock-dark-blue;
+}
+
+body {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    min-height: 100%;
+}
+
+#container {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    padding-top: var(--top-navigation-height);
+    background-color: #EFF0F2;
+}
+
+.main-col {
+    flex-grow: 1;
+}
+
+.main-grid {
+    display: flex;
+    flex-direction: row;
+    height: 100%;
+}
+
+#leftColumn {
+    width: 20% !important;
+    min-width: 300px;
+    box-shadow: 0px 1px 3px rgb(0 0 0 / 13%);
+    background-color: white;
+}
+
+#titlePanel {
+    border-bottom: solid 1px #e7eef4;
+    padding: 1.2em 1em;
+}
+
+#titlePanel h2 {
+  margin: 0 0 0.1em 0 !important
+}
+
+#titlePanel h2 a {
+    color: var(--forgerock-dark-blue);
+    display: block;
+    letter-spacing: normal;
+    font-size: 0.6em;
+    font-weight: normal;
+    line-height: 1.2;
+}
+
+#titlePanel h2 a:hover {
+    color: var(--forgerock-orange);
+}
+
+#versionPanel {
+    color: var(--forgerock-dark-grey);
+    font-style: italic;
+}
+
+#sideMenu {
+    font-size: 0.9em;
+    line-height: 1.4em;
+    padding-top: 0px !important
+}
+
+
+.sideMenuPart > .overview:before {
+    width: 100%;
+    z-index: -1;
+}
+
+.sideMenuPart[data-active] > .overview:before {
+    background: var(--forgerock-light-blue) !important;
+    z-index: 0;
+}
+
+.sideMenuPart > .overview {
+    padding: 0.4em 0;
+}
+
+.sideMenuPart[data-active] > .overview > a {
+    z-index: 1;
+}
+
+#content-container {
+  flex-grow: 1;
+  background-color: #EFF0F2;
+}
+
+.main-content {
+    background-color: white;
+    border-radius: 0.25rem;
+    box-shadow: 0 1px 3px rgb(0 0 0 / 13%);
+    -webkit-box-shadow: 0 1px 3px rgb(0 0 0 / 13%);
+    line-height: var(--doc-line-height);
+    padding: 1.5rem 2.5rem;
+    margin-top: 2em;
+    margin-bottom: 2em;
+    width: calc(80% - 1em);
+}
+
+h1.cover {
+    font-size: 40px;
+    font-weight: normal;
+    letter-spacing: normal !important;
+}
+
+h2 {
+    font-weight: normal;
+}
+
+#searchBar {
+    display: inline-block;
+    position: fixed;
+    right: 1.6em;
+    top: calc(var(--top-navigation-height) + 1.6em);
+}
+
+.search button {
+    margin-top: 0px !important;
+    border-radius: 6px;
+    padding: 8px 3px 0 8px;
+    background: var(--forgerock-green)
+}
+
+

--- a/dokka/logo-icon.svg
+++ b/dokka/logo-icon.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="ede8ca5d-677a-4786-83dc-809e9b4a1e06"
+   data-name="Layer 1"
+   width="0.80000001in"
+   height="0.80000001in"
+   viewBox="0 0 64 64"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs102">
+    <style
+       id="style100">
+      .e7edbb4b-058f-425d-8420-cbd11034c9c0 {
+        fill: #032b75;
+      }
+
+      .a8b9360a-cc3d-4b85-874e-7609cbb6c949 {
+        fill: #f96700;
+      }
+    </style>
+  </defs>
+  <title
+     id="title104">ForgeRock_Vert_Color_Logo_RGB_R_med</title>
+  <g
+     id="g138"
+     transform="translate(-61.674672,3.333253)">
+    <g
+       id="g114">
+      <polygon
+         class="e7edbb4b-058f-425d-8420-cbd11034c9c0"
+         points="81.557,32.69 99.863,0 83.293,5.117 68.008,32.69 "
+         id="polygon106"
+         style="fill:#032b75;fill-opacity:1" />
+      <polygon
+         class="e7edbb4b-058f-425d-8420-cbd11034c9c0"
+         points="81.277,37.911 68.144,37.911 78.725,57.571 92.511,57.571 "
+         id="polygon108"
+         style="fill:#032b75;fill-opacity:1" />
+      <path
+         class="a8b9360a-cc3d-4b85-874e-7609cbb6c949"
+         d="M 119.10514,35.54565 110.567,19.53747 c -5.05555,8.93079 -13.982,25.33709 -17.02645,30.50084 l 4.20714,7.53316 h 8.87612 z"
+         id="path110" />
+      <path
+         class="a8b9360a-cc3d-4b85-874e-7609cbb6c949"
+         d="M 91.027,45.53763 108.07872,15.08811 102.53791,4.80816 c -4.35292,7.69337 -13.33935,23.55209 -17.299,30.36542 z"
+         id="path112" />
+    </g>
+  </g>
+  <metadata
+     id="metadata996">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:title>ForgeRock_Vert_Color_Logo_RGB_R_med</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/dokka/templates/base.ftl
+++ b/dokka/templates/base.ftl
@@ -1,0 +1,46 @@
+<#import "page_metadata.ftl" as page_metadata>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" charset="UTF-8">
+    <@page_metadata.display/>
+    <@template_cmd name="pathToRoot">
+      <script>var pathToRoot = "${pathToRoot}";</script>
+    </@template_cmd>
+    <script src="https://cdn.forgerock.com/backstage/web-components/stable/backstage-web-components-loader.js"></script>
+    <@resources/>
+</head>
+<body>
+    <backstage-site-header active-item="docs" fluid="true" theme="dark" active="docs" searchcategory="docs" searchfamily="sdks" searchversion="latest"></backstage-site-header>
+    <div id="container">
+      <main class="main-col">
+        <div class="main-grid">
+          <div id="leftColumn">
+            <div id="titlePanel">
+              <@template_cmd name="pathToRoot">
+                  <h2><a href="${pathToRoot}index.html">
+                      <@template_cmd name="projectName">
+                          <span>${projectName}</span>
+                      </@template_cmd>
+                  </a></h2>
+              </@template_cmd>
+              <div id="versionPanel">
+                  <@version/>
+              </div>
+            </div>
+            <div id="sideMenu"></div>
+          </div>
+          <div id="content-container">
+              <@content/>
+              <div id="searchBar"></div>
+          </div>
+        </div>
+     </main>
+     <backstage-site-footer></backstage-site-footer>
+  </div>
+  <link rel="import"
+              href="https://cdn.forgerock.com/backstage-web-components/latest/backstage-site-header.html"/>
+  <link rel="import"
+      href="https://cdn.forgerock.com/backstage-web-components/latest/backstage-site-footer.html"/>
+</body>
+</html>

--- a/dokka/templates/page_metadata.ftl
+++ b/dokka/templates/page_metadata.ftl
@@ -1,0 +1,4 @@
+<#macro display>
+    <title>ForgeRock SDK for Android - ${pageName}</title>
+    <link rel="icon" type="image/x-icon" href="https://cdn.forgerock.com/favicon.ico">
+</#macro>


### PR DESCRIPTION
# JIRA Ticket

[SDKS-2334](https://bugster.forgerock.org/jira/browse/SDKS-2334)

# Description

[SDKS-2123](https://bugster.forgerock.org/jira/browse/SDKS-2123) provided the foundation of the kdoc kotlin docs generation (gradle tasks etc...). 
The generated docs however needs to be customized - i.e. use ForgeRock logo/favicon, footer, etc... 

Acceptance criteria: 

The generated kdocs uses ForgeRock branding (Logo, footer, navigation area)
Notes:

See https://kotlinlang.org/docs/dokka-html.html#configuration

# Definition of Done Checklist:

- [ ] Acceptance criteria is met.
- [ ] All tasks listed in the user story have been completed.
- [ ] Coded to standards.
- [ ] Ensure backward compatibility.
- [ ] API reference docs is updated.
- [ ] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] Functional spec is written/updated.
- [ ] contains example code snippets.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).