### PR TITLE
SDKS-2388 Enhance error handling while dealing with Authenticator policies

### DIFF
--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/AuthenticatorManager.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/AuthenticatorManager.java
@@ -18,6 +18,7 @@ import org.forgerock.android.auth.exception.AccountLockException;
 import org.forgerock.android.auth.exception.AuthenticatorException;
 import org.forgerock.android.auth.exception.InvalidNotificationException;
 import org.forgerock.android.auth.exception.MechanismCreationException;
+import org.forgerock.android.auth.exception.MechanismPolicyViolationException;
 import org.forgerock.android.auth.policy.FRAPolicy;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -299,9 +300,9 @@ class AuthenticatorManager {
         Logger.debug(TAG, "Evaluating policies for the new Account");
         FRAPolicyEvaluator.Result result = policyEvaluator.evaluate(context, uri);
         if (!result.isComply()) {
-            listener.onException(new MechanismCreationException("This account cannot be " +
+            listener.onException(new MechanismPolicyViolationException("This account cannot be " +
                     "registered on this device. It violates the following policy: " +
-                    result.getNonCompliancePolicy().getName()));
+                    result.getNonCompliancePolicy().getName(), result.getNonCompliancePolicy()));
             return;
         } else {
             Logger.debug(TAG, "All policies passed for the new Account");

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/exception/MechanismPolicyViolationException.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/exception/MechanismPolicyViolationException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 ForgeRock. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package org.forgerock.android.auth.exception;
+
+import org.forgerock.android.auth.policy.FRAPolicy;
+
+/**
+ * Represents an error while registering a Mechanism due policy violation.
+ */
+public class MechanismPolicyViolationException extends Exception {
+
+    private FRAPolicy cause;
+
+    /**
+     * Create a new exception containing a message.
+     * @param detailMessage The message cause of the exception.
+     * @param cause The policy which caused the exception.
+     */
+    public MechanismPolicyViolationException(String detailMessage, FRAPolicy cause) {
+        super(detailMessage);
+        this.cause = cause;
+    }
+
+    public FRAPolicy getCausingPolicy() {
+        return cause;
+    }
+
+}

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/AuthenticatorManagerTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/AuthenticatorManagerTest.java
@@ -32,6 +32,7 @@ import org.forgerock.android.auth.exception.AuthenticatorException;
 import org.forgerock.android.auth.exception.InvalidNotificationException;
 import org.forgerock.android.auth.exception.InvalidPolicyException;
 import org.forgerock.android.auth.exception.MechanismCreationException;
+import org.forgerock.android.auth.exception.MechanismPolicyViolationException;
 import org.forgerock.android.auth.policy.DeviceTamperingPolicy;
 import org.forgerock.android.auth.policy.FRAPolicy;
 import org.json.JSONException;
@@ -229,7 +230,7 @@ public class AuthenticatorManagerTest extends FRABaseTest {
             pushListenerFuture.get();
             fail("Should throw MechanismCreationException");
         } catch (Exception e) {
-            assertTrue(e.getCause() instanceof MechanismCreationException);
+            assertTrue(e.getCause() instanceof MechanismPolicyViolationException);
             assertTrue(e.getLocalizedMessage().contains("This account cannot be registered on this device"));
         }
     }


### PR DESCRIPTION
# JIRA Ticket

[SDKS-2388](https://bugster.forgerock.org/jira/browse/SDKS-2388) Enhance error handling for developer while dealing with Authenticator policies

# Description

Previously, the only way a developer can figure out which policy caused an exception during registration is by parsing the error message from MechanismCreationException to extract the policy name. The new MechanismPolicyViolationException makes that easier.

# Definition of Done Checklist:

- [x] Acceptance criteria is met.
- [x] All tasks listed in the user story have been completed.
- [x] Coded to standards.
- [x] Ensure backward compatibility.
- [x] API reference docs is updated.
- [x] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] Functional spec is written/updated.
- [ ] contains example code snippets.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).