### PR TITLE
SDKS-2407 Attempt to update locked account should throw an exception

### DIFF
--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/AuthenticatorManager.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/AuthenticatorManager.java
@@ -130,13 +130,13 @@ class AuthenticatorManager {
         return account;
     }
 
-    boolean updateAccount(Account account) {
+    boolean updateAccount(Account account) throws AccountLockException {
         Logger.debug(TAG, "Updating Account with ID '%s'", account.getId());
 
         // Check if Account is locked
         if (account.isLocked()) {
-            Logger.debug(TAG, "Error updating the Account with ID '%s: Account is locked.", account.getId());
-            return false;
+            throw new AccountLockException("This account is locked. It violates the following" +
+                    " policy: " + account.getLockingPolicy());
         }
 
         // Update the account object if it already exist, otherwise return false

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/FRAClient.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/FRAClient.java
@@ -188,8 +188,9 @@ public class FRAClient {
      * not be found or updated.
      * @param account The Account to update.
      * @return boolean as result of the operation
+     * @throws AccountLockException if account is locked
      */
-    public boolean updateAccount(@NonNull Account account) {
+    public boolean updateAccount(@NonNull Account account) throws AccountLockException {
         return this.authenticatorManager.updateAccount(account);
     }
 

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/MechanismParser.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/MechanismParser.java
@@ -181,7 +181,6 @@ abstract class MechanismParser {
             Base64.decode(value, Base64.DEFAULT);
             return true;
         } catch (Exception e) {
-            Logger.warn(TAG, e,"Failed to decode the value: %s", value);
             return false;
         }
     }


### PR DESCRIPTION
# JIRA Ticket

[SDKS-2407](https://bugster.forgerock.org/jira/browse/SDKS-2407) Attempt to update locked account should throw an exception

# Description

When invoking FRClient.updateAccount(), it should throw the AccountLockException if the account is locked.

# Definition of Done Checklist:

- [ ] Acceptance criteria is met.
- [x] All tasks listed in the user story have been completed.
- [x] Coded to standards.
- [ ] Ensure backward compatibility.
- [x] API reference docs is updated.
- [x] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] Functional spec is written/updated.
- [ ] contains example code snippets.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).