### PR TITLE
SDKS-2450 Key Attestation will not support API Level 23

### DIFF
--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/callback/DeviceBindingCallback.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/callback/DeviceBindingCallback.kt
@@ -216,13 +216,11 @@ open class DeviceBindingCallback : AbstractCallback, Binding {
 
         deviceAuthenticator.initialize(userId, Prompt(title, subtitle, description))
 
-        if (deviceAuthenticator.isSupported(context).not()) {
+        if (deviceAuthenticator.isSupported(context, attestation).not()) {
             handleException(DeviceBindingException(Unsupported()))
             return
         }
 
-        //TODO We may need to delete other keys if we only want to maintain one keys on the device
-        //TODO However, we may want to have Application Pin as fallback, so for now, keep multiple keys.
         var keyPair: KeyPair?
         var userKey: UserKey? = null
         try {

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/devicebind/ApplicationPinDeviceAuthenticator.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/devicebind/ApplicationPinDeviceAuthenticator.kt
@@ -51,9 +51,6 @@ open class ApplicationPinDeviceAuthenticator(private val pinCollector: PinCollec
     private val worker = Executors.newSingleThreadScheduledExecutor()
 
     override suspend fun generateKeys(context: Context, attestation: Attestation): KeyPair {
-        if (attestation !is Attestation.None) {
-            throw DeviceBindingException(DeviceBindingErrorStatus.Unsupported())
-        }
         val pin = pinCollector.collectPin(prompt)
         pinRef.set(pin)
         //If we want to allow a user to have an biometric key + application pin,
@@ -88,8 +85,8 @@ open class ApplicationPinDeviceAuthenticator(private val pinCollector: PinCollec
         this.prompt = prompt
     }
 
-    override fun isSupported(context: Context): Boolean {
-        return true
+    override fun isSupported(context: Context, attestation: Attestation): Boolean {
+        return attestation is Attestation.None
     }
 
     /**

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/callback/DeviceBindingCallbackTest.kt
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/callback/DeviceBindingCallbackTest.kt
@@ -90,7 +90,7 @@ class DeviceBindingCallbackTest {
             "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":\"NONE\"}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}";
         val encryptedPref = mock<DeviceBindingRepository>()
         val deviceAuthenticator = mock<None>()
-        whenever(deviceAuthenticator.isSupported(any())).thenReturn(true)
+        whenever(deviceAuthenticator.isSupported(any(), any())).thenReturn(true)
         whenever(deviceAuthenticator.generateKeys(any(), any())).thenReturn(keyPair)
         whenever(deviceAuthenticator.authenticate(any())).thenReturn(Success(keyPair.privateKey))
         whenever(deviceAuthenticator.sign(context, keyPair,
@@ -113,7 +113,7 @@ class DeviceBindingCallbackTest {
             "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":\"NONE\"}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}";
         val deviceAuthenticator = mock<BiometricOnly>()
         whenever(deviceAuthenticator.type()).thenReturn(DeviceBindingAuthenticationType.BIOMETRIC_ONLY)
-        whenever(deviceAuthenticator.isSupported(any())).thenReturn(true)
+        whenever(deviceAuthenticator.isSupported(any(), any())).thenReturn(true)
         whenever(deviceAuthenticator.generateKeys(any(), any())).thenReturn(keyPair)
         whenever(deviceAuthenticator.authenticate(any())).thenReturn(Success(keyPair.privateKey))
         whenever(deviceAuthenticator.sign(context, keyPair,
@@ -141,7 +141,7 @@ class DeviceBindingCallbackTest {
     fun testSuccessPathForBiometricAndCredentialType() = runBlocking {
         val rawContent =
             "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":\"NONE\"}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}";
-        whenever(deviceAuthenticator.isSupported(context)).thenReturn(true)
+        whenever(deviceAuthenticator.isSupported(any(), any())).thenReturn(true)
         whenever(deviceAuthenticator.generateKeys(any(), any())).thenReturn(keyPair)
         whenever(deviceAuthenticator.authenticate(any())).thenReturn(Success(keyPair.privateKey))
         whenever(deviceAuthenticator.sign(context, keyPair,
@@ -163,7 +163,7 @@ class DeviceBindingCallbackTest {
             "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":\"NONE\"}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}";
         val errorCode = -1
         val abort = Abort(code = errorCode)
-        whenever(deviceAuthenticator.isSupported(any())).thenReturn(true)
+        whenever(deviceAuthenticator.isSupported(any(), any())).thenReturn(true)
         whenever(deviceAuthenticator.generateKeys(any(), any())).thenReturn(keyPair)
         whenever(deviceAuthenticator.authenticate(any())).thenReturn(abort)
 
@@ -193,7 +193,7 @@ class DeviceBindingCallbackTest {
     fun testFailurePathForBiometricTimeout(): Unit = runBlocking {
         val rawContent =
             "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":\"NONE\"}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}";
-        whenever(deviceAuthenticator.isSupported(any())).thenReturn(true)
+        whenever(deviceAuthenticator.isSupported(any(), any())).thenReturn(true)
         whenever(deviceAuthenticator.generateKeys(any(), any())).thenReturn(keyPair)
         whenever(deviceAuthenticator.authenticate(any())).thenReturn(Timeout())
 
@@ -220,7 +220,7 @@ class DeviceBindingCallbackTest {
     fun testFailurePathForUnsupported(): Unit = runBlocking {
         val rawContent =
             "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":\"NONE\"}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}";
-        whenever(deviceAuthenticator.isSupported(context)).thenReturn(false)
+        whenever(deviceAuthenticator.isSupported(any(), any())).thenReturn(false)
         val testObject = DeviceBindingCallbackMockTest(rawContent)
         try {
             testObject.testExecute(context,
@@ -251,7 +251,7 @@ class DeviceBindingCallbackTest {
     fun testFailurePathForKeyGeneration(): Unit = runBlocking {
         val rawContent =
             "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":\"NONE\"}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}";
-        whenever(deviceAuthenticator.isSupported(context)).thenReturn(true)
+        whenever(deviceAuthenticator.isSupported(any(), any())).thenReturn(true)
         whenever(deviceAuthenticator.generateKeys(any(), any())).thenThrow(NullPointerException::class.java)
         val testObject = DeviceBindingCallbackMockTest(rawContent)
         try {

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/devicebind/ApplicationPinDeviceAuthenticatorTest.kt
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/devicebind/ApplicationPinDeviceAuthenticatorTest.kt
@@ -59,7 +59,7 @@ class ApplicationPinDeviceAuthenticatorTest {
     @Test
     fun testGenerateKeys() = runBlocking {
         val authenticator = getApplicationPinDeviceAuthenticator()
-        val keyPair = authenticator.generateKeys(context)
+        val keyPair = authenticator.generateKeys(context, Attestation.None)
         assertThat(keyPair).isNotNull
         assertThat(keyPair.keyAlias).isEqualTo(cryptoKey.keyAlias)
         //Test pin is cached for 1 sec
@@ -72,7 +72,7 @@ class ApplicationPinDeviceAuthenticatorTest {
     @Test
     fun testSuccessAuthenticated() = runBlocking {
         val authenticator = getApplicationPinDeviceAuthenticator()
-        val keyPair = authenticator.generateKeys(context)
+        val keyPair = authenticator.generateKeys(context, Attestation.None)
         val status = authenticator.authenticate(context)
         assertThat(status).isEqualTo(Success(keyPair.privateKey))
         assertThat(authenticator.pinRef.get()).isNull()
@@ -101,7 +101,7 @@ class ApplicationPinDeviceAuthenticatorTest {
     @Test
     fun testUnAuthorize(): Unit = runBlocking {
         val authenticator = getApplicationPinDeviceAuthenticator()
-        authenticator.generateKeys(context)
+        authenticator.generateKeys(context, Attestation.None)
         //Using the same byte array buffer
         val authenticator2 =
             object :
@@ -136,7 +136,7 @@ class ApplicationPinDeviceAuthenticatorTest {
     @Test
     fun testAbort(): Unit = runBlocking {
         val authenticator = getApplicationPinDeviceAuthenticator()
-        authenticator.generateKeys(context)
+        authenticator.generateKeys(context, Attestation.None)
         //Using the same byte array buffer
         val authenticator2 =
             object :
@@ -172,16 +172,11 @@ class ApplicationPinDeviceAuthenticatorTest {
 
     }
 
-    @Test(expected = DeviceBindingException::class)
+    @Test
     fun testWithAttestationNotNone(): Unit = runBlocking {
         val authenticator = getApplicationPinDeviceAuthenticator()
-        try {
-            authenticator.generateKeys(context, Attestation.Default("1234".toByteArray()))
-            Assertions.fail("Expected failed")
-        } catch (e: DeviceBindingException) {
-            assertThat(e.status).isEqualTo(Unsupported())
-            throw e
-        }
+        assertThat(authenticator.isSupported(context,
+            Attestation.Default("1234".toByteArray()))).isFalse()
     }
 
     private fun getApplicationPinDeviceAuthenticator(): NoEncryptionApplicationPinDeviceAuthenticator {

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/devicebind/DeviceBindAuthenticationTests.kt
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/devicebind/DeviceBindAuthenticationTests.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.assertj.core.api.Assertions
 import org.forgerock.android.auth.CryptoKey
+import org.forgerock.android.auth.callback.Attestation
 import org.forgerock.android.auth.devicebind.DeviceBindingErrorStatus.*
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -114,7 +115,7 @@ class DeviceBindAuthenticationTests {
         testObject.setKey(cryptoKey)
         testObject.isApi30OrAbove = false
 
-        testObject.generateKeys(context)
+        testObject.generateKeys(context, Attestation.None)
 
         verify(keyBuilder).setUserAuthenticationValidityDurationSeconds(30)
         verify(keyBuilder).setUserAuthenticationRequired(true)
@@ -125,7 +126,7 @@ class DeviceBindAuthenticationTests {
         testObjectBiometric.setKey(cryptoKey)
         testObjectBiometric.isApi30OrAbove = false
 
-        testObjectBiometric.generateKeys(context)
+        testObjectBiometric.generateKeys(context, Attestation.None)
 
         verify(keyBuilder, times(2)).setUserAuthenticationValidityDurationSeconds(30)
         verify(keyBuilder, times(2)).setUserAuthenticationRequired(true)
@@ -145,7 +146,7 @@ class DeviceBindAuthenticationTests {
         testObject.setBiometricHandler(mockBiometricInterface)
         testObject.setKey(cryptoKey)
         testObject.isApi30OrAbove = true
-        testObject.generateKeys(context)
+        testObject.generateKeys(context, Attestation.None)
 
         verify(keyBuilder).setUserAuthenticationParameters(30,
             KeyProperties.AUTH_BIOMETRIC_STRONG or KeyProperties.AUTH_DEVICE_CREDENTIAL)
@@ -166,7 +167,7 @@ class DeviceBindAuthenticationTests {
         testObject.setBiometricHandler(mockBiometricInterface)
         testObject.setKey(cryptoKey)
         testObject.isApi30OrAbove = true
-        testObject.generateKeys(context)
+        testObject.generateKeys(context, Attestation.None)
 
         verify(keyBuilder).setUserAuthenticationParameters(30, KeyProperties.AUTH_BIOMETRIC_STRONG)
         verify(keyBuilder).setUserAuthenticationRequired(true)
@@ -183,7 +184,7 @@ class DeviceBindAuthenticationTests {
 
         val testObject = None()
         testObject.setKey(cryptoKey)
-        testObject.generateKeys(context)
+        testObject.generateKeys(context, Attestation.None)
 
         verify(cryptoKey).createKeyPair(keyBuilder.build())
     }
@@ -195,7 +196,7 @@ class DeviceBindAuthenticationTests {
         testObject.setBiometricHandler(mockBiometricInterface)
         testObject.setKey(cryptoKey)
         testObject.isApi30OrAbove = false
-        assertFalse(testObject.isSupported(context))
+        assertFalse(testObject.isSupported(context, Attestation.None))
     }
 
     @Test
@@ -206,7 +207,7 @@ class DeviceBindAuthenticationTests {
         testObject.setBiometricHandler(mockBiometricInterface)
         testObject.setKey(cryptoKey)
         testObject.isApi30OrAbove = false
-        assertTrue(testObject.isSupported(context))
+        assertTrue(testObject.isSupported(context, Attestation.None))
     }
 
     @Test
@@ -216,13 +217,13 @@ class DeviceBindAuthenticationTests {
         testObject.setBiometricHandler(mockBiometricInterface)
         testObject.setKey(cryptoKey)
         testObject.isApi30OrAbove = false
-        assertTrue(testObject.isSupported(context))
+        assertTrue(testObject.isSupported(context, Attestation.None))
     }
 
     @Test
     fun testSupportedNone() {
         val testObject = None()
-        assertTrue(testObject.isSupported(context))
+        assertTrue(testObject.isSupported(context, Attestation.None))
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
# JIRA Ticket
[SDKS-2450](https://bugster.forgerock.org/jira/browse/SDKS-2450)

# Description

Instead of fixing this issue, we decided to not support Key Attestation for API Level 23.
When using API Level 23, will route to unsupported outcome.

# Definition of Done Checklist:

- [ ] Acceptance criteria is met.
- [ ] All tasks listed in the user story have been completed.
- [ ] Coded to standards.
- [ ] Ensure backward compatibility.
- [ ] API reference docs is updated.
- [ ] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] Functional spec is written/updated.
- [ ] contains example code snippets.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).