### PR TITLE
ForgeRock Android SDK 4.1.0-beta1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.1.0]
+#### Fixed
+- Fixed an issue in the Authenticator module related to combined MFA registration [SDKS-2542]
+
 ## [4.0.0]
 #### Added
 - Upgrade Google Fido Client to support PassKey [SDKS-2243]

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,5 +24,5 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 GROUP=org.forgerock
-VERSION=4.0.0
+VERSION=4.1.0-beta1
 VERSION_CODE=16


### PR DESCRIPTION
# JIRA Ticket

[SDKS-2547](https://bugster.forgerock.org/jira/browse/SDKS-2547) ForgeRock Android SDK 4.1.0-beta1 Release

# Description
Release preparation for the ForgeRock Android SDK 4.1.0-beta1. 
This release include only one bug-fix in the Authenticator module - [SDKS-2542](https://bugster.forgerock.org/jira/browse/SDKS-2542) [FRA] Combined MFA Registration not working properly