### PR TITLE
Add ability to manually refresh access token

### DIFF
--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/FRUser.java
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/FRUser.java
@@ -96,6 +96,19 @@ public class FRUser {
     }
 
     /**
+     * Refresh the {@link AccessToken} asynchronously, force token refresh, no matter the stored {@link AccessToken} is expired or not
+     * refresh the token and persist it.
+     *
+     * @param accessToken AccessToken
+     * @param listener    Listener to listen for refresh event.
+     * @throws AuthenticationRequiredException When failed to Refresh the {@link AccessToken}
+     */
+    @WorkerThread
+    public void refresh(AccessToken accessToken, FRListener<AccessToken> listener) throws AuthenticationRequiredException {
+        sessionManager.refresh(accessToken, listener);
+    }
+
+    /**
      * Retrieve the {@link AccessToken} asynchronously,
      *
      * <p>

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/SessionManager.java
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/SessionManager.java
@@ -44,6 +44,11 @@ public class SessionManager {
     }
 
     @WorkerThread
+    public void refresh(AccessToken accessToken, FRListener<AccessToken> listener) throws AuthenticationRequiredException {
+        tokenManager.refresh(accessToken, listener);
+    }
+
+    @WorkerThread
     public AccessToken getAccessToken() throws AuthenticationRequiredException {
         FRListenerFuture<AccessToken> listener = new FRListenerFuture<>();
         getAccessToken(listener);


### PR DESCRIPTION
# JIRA Ticket

N/A

# Description

Added an ability manually refresh access token regardless of its lifetime. 
Conforms to the same feature on iOS SDK within PR https://github.com/ForgeRock/forgerock-ios-sdk/pull/219