### PR TITLE
ForgeRock Android SDK 4.1.0-beta2 release preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [4.1.0]
 #### Added
-- Interceptor Support for Authenticator module [SDKS-2544]
+- Interceptor support for the Authenticator module [SDKS-2544]
+- Interface for access_token refresh [SDKS-2567]
+- Ability to process new JSON format of IG policy advice [SDKS-2240]
 
 #### Fixed
 - Fixed an issue in the Authenticator module related to combined MFA registration [SDKS-2542]

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,5 +24,5 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 GROUP=org.forgerock
-VERSION=4.1.0-beta1
+VERSION=4.1.0-beta2
 VERSION_CODE=16


### PR DESCRIPTION
# JIRA Ticket

[SDKS-2572](https://bugster.forgerock.org/jira/browse/SDKS-2572) ForgeRock Android SDK 4.1.0-beta2 Release 
