### PR TITLE
Fix CI permissions for GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,14 +3,14 @@ name: CI
 # Trigger on push or pull request
 on:
   pull_request:
-    permissions: write-all
     types: [opened, reopened, synchronize, edited]
-
+  
   push:
     branches:
       - master
       - develop
-
+      
+permissions: write-all
 jobs:
   # Build and run unit tests
   build-and-test:


### PR DESCRIPTION
Fixed permissions in ci.yaml for dependabot.