### PR TITLE
Skip device binding and key attestation e2e tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,9 +29,11 @@ jobs:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
   
   # Build and sign BitBar test artifacts (auth-debug-androidTest-signed.apk and forgerock-auth-debug-androidTest-signed.apk)
+  # Skip this step for PRs created by dependabot
   bitbar-prepare-artifacts:
     name: Prepare device farm artifacts
     uses: ./.github/workflows/bitbar-prepare-artifacts.yaml
+    if: ${{ github.actor != 'dependabot[bot]' }}
     needs: build-and-test
     secrets:
       SIGNING_KEYSTORE: ${{ secrets.SIGNING_KEYSTORE }}

--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ afterEvaluate {
 ossIndexAudit {
     username = System.properties['username']
     password = System.properties['password']
-    excludeVulnerabilityIds = ['CVE-2020-15250', 'sonatype-2019-0673', 'CVE-2022-1799', 'CVE-2022-2390']
+    excludeVulnerabilityIds = ['CVE-2020-15250']
 }
 
 task clean(type: Delete) {

--- a/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/DeviceBindingCallbackTest.java
+++ b/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/DeviceBindingCallbackTest.java
@@ -22,12 +22,14 @@ import org.forgerock.android.auth.NodeListener;
 import org.forgerock.android.auth.NodeListenerFuture;
 import org.forgerock.android.auth.devicebind.ApplicationPinDeviceAuthenticator;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.concurrent.ExecutionException;
 
 @RunWith(AndroidJUnit4.class)
+@Ignore
 public class DeviceBindingCallbackTest extends BaseDeviceBindingTest {
     protected final static String TREE = "device-bind";
 

--- a/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/DeviceBindingListAndUnbind.java
+++ b/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/DeviceBindingListAndUnbind.java
@@ -25,13 +25,13 @@ import org.forgerock.android.auth.devicebind.ApplicationPinDeviceAuthenticator;
 import org.forgerock.android.auth.devicebind.UserKey;
 import org.forgerock.android.auth.exception.ApiException;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-
+@Ignore
 public class DeviceBindingListAndUnbind extends BaseDeviceBindingTest {
     protected final static String TREE = "device-verifier";
     protected final static String APPLICATION_PIN = "1234";

--- a/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/DeviceSigningVerifierApplicationPinCallbackTest.java
+++ b/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/DeviceSigningVerifierApplicationPinCallbackTest.java
@@ -27,13 +27,14 @@ import org.forgerock.android.auth.devicebind.ApplicationPinDeviceAuthenticator;
 import org.forgerock.android.auth.devicebind.DefaultUserKeySelector;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.text.ParseException;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.concurrent.ExecutionException;
-
+@Ignore
 public class DeviceSigningVerifierApplicationPinCallbackTest extends BaseDeviceBindingTest {
     protected final static String TREE = "device-verifier";
     protected final static String APPLICATION_PIN = "1234";

--- a/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/DeviceSigningVerifierCallbackTest.java
+++ b/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/DeviceSigningVerifierCallbackTest.java
@@ -27,6 +27,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -36,6 +37,7 @@ import java.util.Date;
 import java.util.concurrent.ExecutionException;
 
 @RunWith(AndroidJUnit4.class)
+@Ignore
 public class DeviceSigningVerifierCallbackTest extends BaseDeviceBindingTest {
     protected final static String TREE = "device-verifier";
 

--- a/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/KeyAttestationTest.java
+++ b/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/KeyAttestationTest.java
@@ -29,6 +29,7 @@ import org.forgerock.android.auth.NodeListener;
 import org.forgerock.android.auth.NodeListenerFuture;
 import org.forgerock.android.auth.devicebind.ApplicationPinDeviceAuthenticator;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -37,6 +38,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 @RunWith(AndroidJUnit4.class)
+@Ignore
 public class KeyAttestationTest extends BaseDeviceBindingTest {
     protected final static String TREE = "key-attestation";
 


### PR DESCRIPTION
# JIRA Ticket
N/A

# Description
- Skip device binding tests until we build ID Cloud environment.
- Skip running e2e tests on BitBar for PRs created by Dependabot.