### PR TITLE
SDKS-2891 Handle WebAuthn Cancellation inconsistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ private interface CustomCookieInterceptor : FRRequestInterceptor<Action>,
 ```
 #### Fixed
 - Use auth-per-use Key for Device Binding [SDKS-2792]
-
+- Handle WebAuthn cancellation inconsistency [SDKS-2819]
 
 ## [4.2.0]
 #### Added

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/exception/WebAuthnResponseException.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/exception/WebAuthnResponseException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 ForgeRock. All rights reserved.
+ * Copyright (c) 2022 - 2023 ForgeRock. All rights reserved.
  *
  *  This software may be modified and distributed under the terms
  *  of the MIT license. See the LICENSE file for details.
@@ -12,14 +12,11 @@ import com.google.android.gms.fido.fido2.api.common.ErrorCode
 /**
  * An Exception representation of [AuthenticatorErrorResponse]
  */
-class WebAuthnResponseException(authenticatorErrorResponse: AuthenticatorErrorResponse) :
-    Exception(authenticatorErrorResponse.errorMessage) {
-    val errorCode: ErrorCode
-    val errorCodeAsInt: Int
+class WebAuthnResponseException(val errorCode: ErrorCode, errorMessage: String?) :
+    Exception(errorMessage) {
 
-    init {
-        errorCode = authenticatorErrorResponse.errorCode
-        errorCodeAsInt = authenticatorErrorResponse.errorCodeAsInt
+    constructor(authenticatorErrorResponse: AuthenticatorErrorResponse) :
+            this(authenticatorErrorResponse.errorCode, authenticatorErrorResponse.errorMessage) {
     }
 
     /**


### PR DESCRIPTION
# JIRA Ticket

https://bugster.forgerock.org/jira/browse/SDKS-2819

# Description

Handle WebAuthn Cancellation inconsistency, Google FIDO library may return Activity.RESULT_CANCELED instead of AuthenticatorErrorResponse with NOT_ALLOW_ERROR when cancelling the FIDO authentication process, the SDK handles both scenario, and translate Activity.RESULT_CANCELED to WebAuthn NOT_ALLOW_ERROR