### PR TITLE
SDKS-2784 Test coverage for the App Integrity feature

### DIFF
--- a/forgerock-auth-ui/src/main/java/org/forgerock/android/auth/ui/CallbackFragmentFactory.java
+++ b/forgerock-auth-ui/src/main/java/org/forgerock/android/auth/ui/CallbackFragmentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2022 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 - 2023 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -58,6 +58,7 @@ public class CallbackFragmentFactory {
         register(SuspendedTextOutputCallback.class, SuspendedTextOutputCallbackFragment.class);
         register(ReCaptchaCallback.class, ReCaptchaCallbackFragment.class);
         register(ConsentMappingCallback.class, ConsentMappingCallbackFragment.class);
+        register(AppIntegrityCallback.class, AppIntegrityCallbackFragment.class);
         register(DeviceProfileCallback.class, DeviceProfileCallbackFragment.class);
         register(DeviceBindingCallback.class, DeviceBindingCallbackFragment.class);
         register(DeviceSigningVerifierCallback.class, DeviceSigningVerifierCallbackFragment.class);

--- a/forgerock-auth-ui/src/main/java/org/forgerock/android/auth/ui/callback/AppIntegrityCallbackFragment.java
+++ b/forgerock-auth-ui/src/main/java/org/forgerock/android/auth/ui/callback/AppIntegrityCallbackFragment.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2023 ForgeRock. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package org.forgerock.android.auth.ui.callback;
+
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import androidx.fragment.app.Fragment;
+
+import org.forgerock.android.auth.FRListener;
+import org.forgerock.android.auth.Logger;
+import org.forgerock.android.auth.callback.AppIntegrityCallback;
+import org.forgerock.android.auth.ui.R;
+
+import static android.view.View.GONE;
+
+/**
+ * A simple {@link Fragment} subclass.
+ */
+public class AppIntegrityCallbackFragment extends CallbackFragment<AppIntegrityCallback> {
+
+    private TextView message;
+    private ProgressBar progressBar;
+
+    public AppIntegrityCallbackFragment() {
+        // Required empty public constructor
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+
+
+        // Inflate the layout for this fragment
+        View view = inflater.inflate(R.layout.fragment_app_integrity_callback, container, false);
+        message = view.findViewById(R.id.message);
+        progressBar = view.findViewById(R.id.appIntegrityApiCallProgress);
+
+        if (node.getCallbacks().size() == 1) { //auto submit if there is one node
+            progressBar.setVisibility(View.VISIBLE);
+            message.setText("Performing " + callback.getRequestType() + " call...");
+        } else {
+            progressBar.setVisibility(GONE);
+            message.setVisibility(GONE);
+        }
+
+        proceed();
+        return view;
+    }
+
+    private void proceed() {
+        final Activity thisActivity = (Activity) this.getActivity();
+        callback.requestIntegrityToken(this.getContext(), new FRListener<Void>() {
+            @Override
+            public void onSuccess(Void result) {
+                thisActivity.runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        message.setVisibility(GONE);
+                        progressBar.setVisibility(GONE);
+                        if (node.getCallbacks().size() == 1) { //auto submit if there is one node
+                            next();
+                        }
+                    }
+                });
+            }
+
+            @Override
+            public void onException(Exception e) {
+                message.setVisibility(GONE);
+                progressBar.setVisibility(GONE);
+                Logger.error("AppIntegrityCallback", e.toString());
+                cancel(e);
+            }
+        });
+    }
+}

--- a/forgerock-auth-ui/src/main/res/layout/fragment_app_integrity_callback.xml
+++ b/forgerock-auth-ui/src/main/res/layout/fragment_app_integrity_callback.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2019 - 2023 ForgeRock. All rights reserved.
+  ~
+  ~ This software may be modified and distributed under the terms
+  ~ of the MIT license. See the LICENSE file for details.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".callback.AppIntegrityCallbackFragment" android:id="@+id/frameLayout">
+
+    <TextView
+        android:id="@+id/message"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <ProgressBar
+        android:id="@+id/appIntegrityApiCallProgress"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        app:layout_constraintBottom_toTopOf="@+id/message"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/forgerock-auth/build.gradle
+++ b/forgerock-auth/build.gradle
@@ -147,6 +147,9 @@ dependencies {
     androidTestImplementation 'com.madgag.spongycastle:bcpkix-jdk15on:1.58.0.0'
     androidTestImplementation 'androidx.security:security-crypto:1.1.0-alpha06'
 
+    //App Integrity
+    androidTestImplementation 'com.google.android.play:integrity:1.3.0'
+
     testImplementation 'androidx.test:core:1.5.0'
     testImplementation 'androidx.test.ext:junit:1.1.5'
     testImplementation 'androidx.test:runner:1.5.2'

--- a/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/AppIntegrityCallbackTest.java
+++ b/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/AppIntegrityCallbackTest.java
@@ -1,0 +1,387 @@
+/*
+ * Copyright (c) 2022 - 2023 ForgeRock. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package org.forgerock.android.auth.callback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.assertj.core.api.Assertions;
+import org.forgerock.android.auth.FRAuth;
+import org.forgerock.android.auth.FRListener;
+import org.forgerock.android.auth.FROptions;
+import org.forgerock.android.auth.FROptionsBuilder;
+import org.forgerock.android.auth.FRSession;
+import org.forgerock.android.auth.Logger;
+import org.forgerock.android.auth.Node;
+import org.forgerock.android.auth.NodeListener;
+import org.forgerock.android.auth.NodeListenerFuture;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+@RunWith(AndroidJUnit4.class)
+public class AppIntegrityCallbackTest  {
+
+    protected static Context context = ApplicationProvider.getApplicationContext();
+
+    protected final static String AM_URL = "https://localam.petrov.ca/openam";
+    protected final static String REALM = "root";
+    protected final static String OAUTH_CLIENT = "AndroidTest";
+    protected final static String OAUTH_REDIRECT_URI = "org.forgerock.demo:/oauth2redirect";
+    protected final static String SCOPE = "openid profile email address phone";
+
+    protected final static String USERNAME = "sdkuser";
+    protected final static String TREE = "TEST-app-integrity";
+
+    @Rule
+    public Timeout timeout = new Timeout(20000, TimeUnit.MILLISECONDS);
+
+    @BeforeClass
+    public static void setUpSDK() {
+        Logger.set(Logger.Level.DEBUG);
+
+        // Prepare dynamic configuration object
+        FROptions options = FROptionsBuilder.build(builder -> {
+            builder.server(serverBuilder -> {
+                serverBuilder.setUrl(AM_URL);
+                serverBuilder.setRealm(REALM);
+                return null;
+            });
+            builder.oauth(oauth -> {
+                oauth.setOauthClientId(OAUTH_CLIENT);
+                oauth.setOauthRedirectUri(OAUTH_REDIRECT_URI);
+                oauth.setOauthScope(SCOPE);
+                return null;
+            });
+            return null;
+        });
+
+        FRAuth.start(context, options);
+    }
+
+    @After
+    public void logoutSession() {
+        if (FRSession.getCurrentSession() != null) {
+            FRSession.getCurrentSession().logout();
+        }
+    }
+
+    @Test
+    public void testAppIntegrityCallback() throws ExecutionException, InterruptedException {
+        // This test checks the returned callback from the App Integrity node
+        // Is also tests that the AppIntegrity node triggers correct "custom" client error outcome... (in this case "abort")
+        final int[] abort = {0};
+
+        NodeListenerFuture<FRSession> nodeListenerFuture = new AppIntegrityNodeListener(context, "default") {
+            final NodeListener<FRSession> nodeListener = this;
+
+            @Override
+            public void onCallbackReceived(Node node) {
+                if (node.getCallback(AppIntegrityCallback.class) != null) {
+                    AppIntegrityCallback callback = node.getCallback(AppIntegrityCallback.class);
+
+                    assertThat(callback.getRequestType()).isEqualTo(RequestType.CLASSIC);
+                    assertThat(callback.getProjectNumber()).isEqualTo("684644441808");
+                    Assert.assertNotNull(callback.getNonce());
+
+                    // Set "Abort" outcome...
+                    callback.setClientError("Abort");
+                    node.next(context, nodeListener);
+                    return;
+                }
+                if (node.getCallback(TextOutputCallback.class) != null) {
+                    TextOutputCallback callback = node.getCallback(TextOutputCallback.class);
+                    assertThat(callback.getMessage()).isEqualTo("Abort");
+                    abort[0]++;
+                    node.next(context, nodeListener);
+                    return;
+                }
+                super.onCallbackReceived(node);
+            }
+        };
+
+        FRSession.authenticate(context, TREE, nodeListenerFuture);
+        Assert.assertNotNull(nodeListenerFuture.get());
+
+        // Ensure that the journey finishes with success
+        Assert.assertNotNull(FRSession.getCurrentSession());
+        Assert.assertNotNull(FRSession.getCurrentSession().getSessionToken());
+
+        // Make sure AppIntegrity node fired the "abort" outcome
+        assertThat(abort[0]).isEqualTo(1);
+    }
+
+    @Test
+    public void testAppIntegrityClassic() throws ExecutionException, InterruptedException {
+        // This test performs a CLASSIC api call
+        final int[] successClientCall = {0};
+        final int[] failureOutcome = {0};
+
+        NodeListenerFuture<FRSession> nodeListenerFuture = new AppIntegrityNodeListener(context, "classic") {
+            final NodeListener<FRSession> nodeListener = this;
+
+            @Override
+            public void onCallbackReceived(Node node) {
+                if (node.getCallback(AppIntegrityCallback.class) != null) {
+                    AppIntegrityCallback callback = node.getCallback(AppIntegrityCallback.class);
+
+                    // Perform app integrity check
+                    callback.requestIntegrityToken(context, new FRListener<Void>() {
+                        @Override
+                        public void onSuccess(Void result) {
+                            successClientCall[0]++;
+                            node.next(context, nodeListener);
+
+                        }
+                        @Override
+                        public void onException(Exception e) {
+                            Assertions.fail("Unexpected failure during client app integrity call!");
+                            node.next(context, nodeListener);
+                        }
+                    });
+
+                    return;
+                }
+                if (node.getCallback(TextOutputCallback.class) != null) {
+                    // The node configuration in this case sets the verdict variable in the shared stated
+                    TextOutputCallback callback = node.getCallback(TextOutputCallback.class);
+                    assertThat(callback.getMessage()).isEqualTo("Failure");
+                    failureOutcome[0]++;
+                    node.next(context, nodeListener);
+                    return;
+                }
+                super.onCallbackReceived(node);
+            }
+        };
+
+        FRSession.authenticate(context, TREE, nodeListenerFuture);
+        Assert.assertNotNull(nodeListenerFuture.get());
+
+        // Ensure that the journey finishes with success
+        Assert.assertNotNull(FRSession.getCurrentSession());
+        Assert.assertNotNull(FRSession.getCurrentSession().getSessionToken());
+
+        assertThat(successClientCall[0]).isEqualTo(1);
+        assertThat(failureOutcome[0]).isEqualTo(1);
+    }
+
+    @Test
+    public void testAppIntegrityStandard() throws ExecutionException, InterruptedException {
+        // This test performs a STANDARD api call
+        final int[] successClientCall = {0};
+        final int[] failureOutcome = {0};
+
+        NodeListenerFuture<FRSession> nodeListenerFuture = new AppIntegrityNodeListener(context, "standard") {
+            final NodeListener<FRSession> nodeListener = this;
+
+            @Override
+            public void onCallbackReceived(Node node) {
+                if (node.getCallback(AppIntegrityCallback.class) != null) {
+                    AppIntegrityCallback callback = node.getCallback(AppIntegrityCallback.class);
+
+                    // Perform app integrity check
+                    callback.requestIntegrityToken(context, new FRListener<Void>() {
+                        @Override
+                        public void onSuccess(Void result) {
+                            successClientCall[0]++;
+                            node.next(context, nodeListener);
+
+                        }
+                        @Override
+                        public void onException(Exception e) {
+                            Assertions.fail("Unexpected failure during client app integrity call!");
+                            node.next(context, nodeListener);
+                        }
+                    });
+
+                    return;
+                }
+                if (node.getCallback(TextOutputCallback.class) != null) {
+                    // The node configuration in this case sets the verdict variable in the shared stated
+                    TextOutputCallback callback = node.getCallback(TextOutputCallback.class);
+                    assertThat(callback.getMessage()).isEqualTo("Failure");
+                    failureOutcome[0]++;
+                    node.next(context, nodeListener);
+                    return;
+                }
+                super.onCallbackReceived(node);
+            }
+        };
+
+        FRSession.authenticate(context, TREE, nodeListenerFuture);
+        Assert.assertNotNull(nodeListenerFuture.get());
+
+        // Ensure that the journey finishes with success
+        Assert.assertNotNull(FRSession.getCurrentSession());
+        Assert.assertNotNull(FRSession.getCurrentSession().getSessionToken());
+
+        assertThat(successClientCall[0]).isEqualTo(1);
+        assertThat(failureOutcome[0]).isEqualTo(1);
+    }
+
+    @Test
+    public void testAppIntegrityVerdictVarON() throws ExecutionException, InterruptedException {
+        // This test checks if VERDICT variable is set in the shared stated when enabled...
+        final int[] verdictExists = {0};
+
+        NodeListenerFuture<FRSession> nodeListenerFuture = new AppIntegrityNodeListener(context, "verdict-on") {
+            final NodeListener<FRSession> nodeListener = this;
+
+            @Override
+            public void onCallbackReceived(Node node) {
+                if (node.getCallback(AppIntegrityCallback.class) != null) {
+                    AppIntegrityCallback callback = node.getCallback(AppIntegrityCallback.class);
+
+                    // Perform app integrity check
+                    callback.requestIntegrityToken(context, new FRListener<Void>() {
+                        @Override
+                        public void onSuccess(Void result) {
+                            node.next(context, nodeListener);
+                        }
+                        @Override
+                        public void onException(Exception e) {
+                            Assertions.fail("Unexpected failure during client app integrity call!");
+                        }
+                    });
+                    return;
+                }
+                if (node.getCallback(TextOutputCallback.class) != null) {
+                    // The node configuration in this case sets the verdict variable in the shared stated
+                    TextOutputCallback callback = node.getCallback(TextOutputCallback.class);
+                    assertThat(callback.getMessage()).isEqualTo("Verdict Exists");
+                    verdictExists[0]++;
+                    node.next(context, nodeListener);
+                    return;
+                }
+                super.onCallbackReceived(node);
+            }
+        };
+
+        FRSession.authenticate(context, TREE, nodeListenerFuture);
+        Assert.assertNotNull(nodeListenerFuture.get());
+
+        // Ensure that the journey finishes with success
+        Assert.assertNotNull(FRSession.getCurrentSession());
+        Assert.assertNotNull(FRSession.getCurrentSession().getSessionToken());
+
+        assertThat(verdictExists[0]).isEqualTo(1);
+    }
+
+    @Test
+    public void testAppIntegrityVerdictVarOFF() throws ExecutionException, InterruptedException {
+        // This test checks if VERDICT variable is set in the shared stated - in this case the node configuration is set to OFF
+        final int[] verdictDoesNOTexist = {0};
+
+        NodeListenerFuture<FRSession> nodeListenerFuture = new AppIntegrityNodeListener(context, "verdict-off") {
+            final NodeListener<FRSession> nodeListener = this;
+
+            @Override
+            public void onCallbackReceived(Node node) {
+                if (node.getCallback(AppIntegrityCallback.class) != null) {
+                    AppIntegrityCallback callback = node.getCallback(AppIntegrityCallback.class);
+
+                    callback.requestIntegrityToken(context, new FRListener<Void>() {
+                        @Override
+                        public void onSuccess(Void result) {
+                            node.next(context, nodeListener);
+                        }
+                        @Override
+                        public void onException(Exception e) {
+                            Assertions.fail("Unexpected failure during client app integrity call!");
+                            node.next(context, nodeListener);
+                        }
+                    });
+                    return;
+                }
+                if (node.getCallback(TextOutputCallback.class) != null) {
+                    // The node configuration in this case sets the verdict variable in the shared stated
+                    TextOutputCallback callback = node.getCallback(TextOutputCallback.class);
+                    assertThat(callback.getMessage()).isEqualTo("Verdict DOES NOT exist");
+                    verdictDoesNOTexist[0]++;
+                    node.next(context, nodeListener);
+                    return;
+                }
+                super.onCallbackReceived(node);
+            }
+        };
+
+        FRSession.authenticate(context, TREE, nodeListenerFuture);
+        Assert.assertNotNull(nodeListenerFuture.get());
+
+        // Ensure that the journey finishes with success
+        Assert.assertNotNull(FRSession.getCurrentSession());
+        Assert.assertNotNull(FRSession.getCurrentSession().getSessionToken());
+
+        assertThat(verdictDoesNOTexist[0]).isEqualTo(1);
+    }
+
+    @Test
+    public void testAppIntegrityClientError() throws ExecutionException, InterruptedException {
+        // Verifies that client errors a properly handled by the SDK and trigger the default outcome of the Integrity node
+        final int[] clientError = {0};
+
+        NodeListenerFuture<FRSession> nodeListenerFuture = new AppIntegrityNodeListener(context, "client-error") {
+            final NodeListener<FRSession> nodeListener = this;
+
+            @Override
+            public void onCallbackReceived(Node node) {
+                if (node.getCallback(AppIntegrityCallback.class) != null) {
+                    AppIntegrityCallback callback = node.getCallback(AppIntegrityCallback.class);
+
+                    // Perform app integrity check
+                    callback.requestIntegrityToken(context, new FRListener<Void>() {
+                        @Override
+                        public void onSuccess(Void result) {
+                            Assertions.fail("Unexpected successful integrity call!");
+                            node.next(context, nodeListener);
+                        }
+                        @Override
+                        public void onException(Exception e) {
+                            // Don't do much...
+                            Logger.debug("testAppIntegrityClientError", e.getMessage());
+                            node.next(context, nodeListener);
+                        }
+                    });
+                    return;
+                }
+                if (node.getCallback(TextOutputCallback.class) != null) {
+                    // The node configuration in this case sets the verdict variable in the shared stated
+                    TextOutputCallback callback = node.getCallback(TextOutputCallback.class);
+                    assertThat(callback.getMessage()).isEqualTo("Client Error");
+                    clientError[0]++;
+                    node.next(context, nodeListener);
+                    return;
+                }
+                super.onCallbackReceived(node);
+            }
+        };
+
+        FRSession.authenticate(context, TREE, nodeListenerFuture);
+        Assert.assertNotNull(nodeListenerFuture.get());
+
+        // Ensure that the journey finishes with success
+        Assert.assertNotNull(FRSession.getCurrentSession());
+        Assert.assertNotNull(FRSession.getCurrentSession().getSessionToken());
+
+        assertThat(clientError[0]).isEqualTo(1);
+    }
+}
+
+
+

--- a/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/AppIntegrityNodeListener.java
+++ b/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/AppIntegrityNodeListener.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022 - 2023 ForgeRock. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package org.forgerock.android.auth.callback;
+
+import static org.forgerock.android.auth.AndroidBaseTest.USERNAME;
+
+import android.content.Context;
+
+import org.forgerock.android.auth.FRSession;
+import org.forgerock.android.auth.Node;
+import org.forgerock.android.auth.NodeListenerFuture;
+
+import java.util.List;
+
+public class AppIntegrityNodeListener extends NodeListenerFuture<FRSession> {
+
+    private Context context;
+    private String nodeConfiguration;
+
+    public AppIntegrityNodeListener(Context context, String nodeConfiguration) {
+        this.context = context;
+        this.nodeConfiguration = nodeConfiguration;
+    }
+
+    @Override
+    public void onCallbackReceived(Node node) {
+        if (node.getCallback(ChoiceCallback.class) != null) {
+            ChoiceCallback choiceCallback = node.getCallback(ChoiceCallback.class);
+            List<String> choices = choiceCallback.getChoices();
+            int choiceIndex = choices.indexOf(nodeConfiguration);
+            choiceCallback.setSelectedIndex(choiceIndex);
+            node.next(context, this);
+        }
+        if (node.getCallback(NameCallback.class) != null) {
+            node.getCallback(NameCallback.class).setName(USERNAME);
+            node.next(context, this);
+        }
+    }
+}

--- a/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/BaseDeviceBindingTest.java
+++ b/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/BaseDeviceBindingTest.java
@@ -31,7 +31,7 @@ public abstract class BaseDeviceBindingTest {
     protected static Context context = ApplicationProvider.getApplicationContext();
 
     // This test uses dynamic configuration with the following settings:
-    protected final static String AM_URL = "https://openam-dbind.forgeblocks.com/am";
+    protected final static String AM_URL = "https://openam-sdks.forgeblocks.com/am";
     protected final static String REALM = "alpha";
     protected final static String OAUTH_CLIENT = "AndroidTest";
     protected final static String OAUTH_REDIRECT_URI = "org.forgerock.demo:/oauth2redirect";

--- a/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/DeviceBindingListAndUnbind.java
+++ b/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/DeviceBindingListAndUnbind.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-@Ignore
 public class DeviceBindingListAndUnbind extends BaseDeviceBindingTest {
     protected final static String TREE = "device-verifier";
     protected final static String APPLICATION_PIN = "1234";

--- a/samples/auth/build.gradle
+++ b/samples/auth/build.gradle
@@ -99,6 +99,9 @@ dependencies {
     implementation 'com.google.android.gms:play-services-auth:20.5.0'
     implementation 'com.facebook.android:facebook-login:16.0.0'
 
+    //For App integrity
+    implementation 'com.google.android.play:integrity:1.3.0'
+
     //Device Binding + JWT
     implementation 'com.nimbusds:nimbus-jose-jwt:9.25'
     implementation 'androidx.biometric:biometric-ktx:1.2.0-alpha05'


### PR DESCRIPTION
# JIRA Ticket

[SDKS-2784](https://bugster.forgerock.org/jira/browse/SDKS-2784) [Android] App Integrity QA

# Description

- Added e2e test cases for the App Integrity feature. These test cases work with "live" AM server and require the following authentication tree:

<img width="1342" alt="image" src="https://github.com/ForgeRock/forgerock-android-sdk/assets/1580960/2a2d9777-707f-4f78-a8e4-52643615afa5">

At this moment the test cases will run against the https://localam.petrov.ca/openam instance (which contains this tree and additional configurations)...
- Updated the `auth` sample app - added support for `AppIntegrityCallback`
- Switched the device binding test cases to run against https://openam-sdks.forgeblocks.com/am