### PR TITLE
SDKS-2935 Added test coverage the failure outcome in the DeviceSigningVerifier node

### DIFF
--- a/.github/workflows/bitbar-prepare-artifacts.yaml
+++ b/.github/workflows/bitbar-prepare-artifacts.yaml
@@ -42,6 +42,10 @@ jobs:
       - name: Prepare device farm artifacts
         run: ./gradlew assembleDebugAndroidTest --stacktrace --no-daemon
 
+      # List the available build tools versions see https://github.com/r0adkll/sign-android-release/issues/84
+      - name: List build tools versions
+        run: ls /Users/runner/Library/Android/sdk/build-tools/
+
       # Sign auth-debug-androidTest.apk
       - name: Sign auth-debug-androidTest.apk
         uses: r0adkll/sign-android-release@v1
@@ -52,7 +56,7 @@ jobs:
           keyStorePassword: ${{ secrets.SIGNING_KEYSTORE_PASSWORD }}
           keyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
         env:
-          BUILD_TOOLS_VERSION: "30.0.3"
+          BUILD_TOOLS_VERSION: "34.0.0"
 
       # Sign forgerock-auth-debug-androidTest.apk
       - name: Sign forgerock-auth-debug-androidTest.apk
@@ -64,7 +68,7 @@ jobs:
           keyStorePassword: ${{ secrets.SIGNING_KEYSTORE_PASSWORD }}
           keyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
         env:
-          BUILD_TOOLS_VERSION: "30.0.3"
+          BUILD_TOOLS_VERSION: "34.0.0"
 
       # Publish the signed APKs as build artifacts
       - name: Publish auth-debug-androidTest.apk

--- a/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/BaseDeviceBindingTest.java
+++ b/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/BaseDeviceBindingTest.java
@@ -31,7 +31,7 @@ public abstract class BaseDeviceBindingTest {
     protected static Context context = ApplicationProvider.getApplicationContext();
 
     // This test uses dynamic configuration with the following settings:
-    protected final static String AM_URL = "https://openam-sdks.forgeblocks.com/am";
+    protected final static String AM_URL = "https://openam-spetrov.forgeblocks.com/am";
     protected final static String REALM = "alpha";
     protected final static String OAUTH_CLIENT = "AndroidTest";
     protected final static String OAUTH_REDIRECT_URI = "org.forgerock.demo:/oauth2redirect";

--- a/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/CustomDeviceSigningVerifierCallback.kt
+++ b/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/CustomDeviceSigningVerifierCallback.kt
@@ -7,6 +7,8 @@
 
 package org.forgerock.android.auth.callback
 
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import com.nimbusds.jose.JOSEObjectType
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.JWSHeader
@@ -16,7 +18,8 @@ import com.nimbusds.jwt.SignedJWT
 import org.json.JSONObject
 import java.security.KeyPairGenerator
 import java.security.interfaces.RSAPrivateKey
-import java.util.*
+import java.util.Calendar
+import java.util.Date
 
 class CustomDeviceSigningVerifierCallback : DeviceSigningVerifierCallback {
     constructor() : super()
@@ -41,6 +44,9 @@ class CustomDeviceSigningVerifierCallback : DeviceSigningVerifierCallback {
         val header =
             JWSHeader.Builder(JWSAlgorithm.RS512).type(JOSEObjectType.JWT).keyID(kid).build()
         val payload = JWTClaimsSet.Builder().subject(sub).claim("challenge", challenge)
+            .issuer(ApplicationProvider.getApplicationContext<Context>().packageName)
+            .issueTime(Calendar.getInstance().time)
+            .notBeforeTime(Calendar.getInstance().time)
             .expirationTime(getExpiration(null)).build()
         val signedJWT = SignedJWT(header, payload)
         signedJWT.sign(RSASSASigner(rsaKey.private as RSAPrivateKey))


### PR DESCRIPTION
# JIRA Ticket

[SDKS-2935](https://bugster.forgerock.org/jira/browse/SDKS-2935): If a user is set to `inactive` the `DeviceSigningVerifier` node throws an exception

# Description
- Added test coverage for the `Capture Failure` option in the Device Signing Verifier node
- Added test coverage for the `DeviceSigningVerifierNode.FAILURE` shared state variable