### PR TITLE
ForgeRock Android SDK 4.3.1 Release Preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
+## [4.3.1]
+#### Fixed
+- Fixed and issue where the SDK was crashing during device binding on Android 9 devices [SDKS-2948]
+
 ## [4.3.0]
 #### Added
 - Added the ability to customize cookie headers in outgoing requests from the SDK [SDKS-2780]
 - Added the ability to insert custom claims when performing device signing verification [SDKS-2787]
 - Added client-side support for the `AppIntegrity` callback [SDKS-2631]
-
 
 #### Fixed
 - The SDK now uses `auth-per-use` keys for Device Binding [SDKS-2797]

--- a/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/AppIntegrityCallbackTest.java
+++ b/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/AppIntegrityCallbackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 - 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2022 - 2024 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/AppIntegrityCallbackTest.java
+++ b/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/AppIntegrityCallbackTest.java
@@ -40,8 +40,8 @@ public class AppIntegrityCallbackTest  {
 
     protected static Context context = ApplicationProvider.getApplicationContext();
 
-    protected final static String AM_URL = "https://localam.petrov.ca/openam";
-    protected final static String REALM = "root";
+    protected final static String AM_URL = "https://openam-integrity1.forgeblocks.com/am";
+    protected final static String REALM = "alpha";
     protected final static String OAUTH_CLIENT = "AndroidTest";
     protected final static String OAUTH_REDIRECT_URI = "org.forgerock.demo:/oauth2redirect";
     protected final static String SCOPE = "openid profile email address phone";

--- a/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/BaseDeviceBindingTest.java
+++ b/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/BaseDeviceBindingTest.java
@@ -31,7 +31,7 @@ public abstract class BaseDeviceBindingTest {
     protected static Context context = ApplicationProvider.getApplicationContext();
 
     // This test uses dynamic configuration with the following settings:
-    protected final static String AM_URL = "https://openam-spetrov.forgeblocks.com/am";
+    protected final static String AM_URL = "https://openam-dbind.forgeblocks.com/am";
     protected final static String REALM = "alpha";
     protected final static String OAUTH_CLIENT = "AndroidTest";
     protected final static String OAUTH_REDIRECT_URI = "org.forgerock.demo:/oauth2redirect";

--- a/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/BaseDeviceBindingTest.java
+++ b/forgerock-auth/src/androidTest/java/org/forgerock/android/auth/callback/BaseDeviceBindingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2023 - 2024 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/ServerConfigTest.java
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/ServerConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 - 2024 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -80,7 +80,7 @@ public class ServerConfigTest {
         ServerConfig serverConfig = ServerConfig.builder()
                 .context(context)
                 .url("https://api.ipify.org")
-                .pin("9hNxmEFgLKGJXqgp61hyb8yIyiT9u0vgDZh4y8TmY/M=")
+                .pin("HMSZyV3whmhwmQlqNPIlvpQA9AHHQ9aj1CEDqFkAuyE=")
                 .build();
 
         OkHttpClient client = OkHttpClientProvider.getInstance().lookup(serverConfig);
@@ -122,7 +122,7 @@ public class ServerConfigTest {
         ServerConfig serverConfig = ServerConfig.builder()
                 .context(context)
                 .url("https://api.ipify.org")
-                .pin("9hNxmEFgLKGJXqgp61hyb8yIyiT9u0vgDZh4y8TmY/M=")
+                .pin("HMSZyV3whmhwmQlqNPIlvpQA9AHHQ9aj1CEDqFkAuyE=")
                 .pin("invalid")
                 .build();
 
@@ -214,7 +214,7 @@ public class ServerConfigTest {
                 .context(context)
                 .url("https://api.ipify.org")
                 .buildStep(builder -> builder.certificatePinner(
-                        new CertificatePinner.Builder().add("api.ipify.org", "sha1/2vB3hhEJ98C5efhhWpxtD2wxYek=" ).build()))
+                        new CertificatePinner.Builder().add("api.ipify.org", "sha1/40WpRckJNrzdAexnwLvKG7aK3qk=" ).build()))
                 .build();
 
         OkHttpClient client = OkHttpClientProvider.getInstance().lookup(serverConfig);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 - 2022 ForgeRock. All rights reserved.
+# Copyright (c) 2019 - 2024 ForgeRock. All rights reserved.
 #
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,8 +23,8 @@ kotlin.code.style=official
 android.useAndroidX=true
 
 GROUP=org.forgerock
-VERSION=4.3.0
-VERSION_CODE=19
+VERSION=4.3.1
+VERSION_CODE=20
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false


### PR DESCRIPTION
# JIRA Ticket

[SDKS-2963](https://bugster.forgerock.org/jira/browse/SDKS-2963) ForgeRock Android SDK 4.3.1 Release

# Description

- Updated `CHANGELOG.md`
- Update the version number in `gradle.properties` file
- Fixed `device bind` and `device singing` test cases (the IDCloud instance)
- Fixed SSL pinning test cases (the certificate of `api.ipify.org` has been recently updated)