### PR TITLE
SDKS-3015 SDK 4.4.0 Release Testing

### DIFF
--- a/forgerock-integration-tests/src/androidTest/java/org/forgerock/android/auth/AndroidBaseTest.java
+++ b/forgerock-integration-tests/src/androidTest/java/org/forgerock/android/auth/AndroidBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2024 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -7,21 +7,32 @@
 
 package org.forgerock.android.auth;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import android.content.Context;
 
 import androidx.test.core.app.ApplicationProvider;
 
+import org.forgerock.android.auth.callback.Callback;
+import org.forgerock.android.auth.callback.KbaCreateCallback;
+import org.forgerock.android.auth.callback.NameCallback;
+import org.forgerock.android.auth.callback.PasswordCallback;
+import org.forgerock.android.auth.callback.StringAttributeInputCallback;
+import org.forgerock.android.auth.callback.TermsAndConditionsCallback;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.Timeout;
 
+import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 public abstract class AndroidBaseTest {
 
     @Rule
     public Timeout timeout = new Timeout(10000, TimeUnit.MILLISECONDS);
-    protected Context context = ApplicationProvider.getApplicationContext();
+    protected static Context context = ApplicationProvider.getApplicationContext();
     public static String USERNAME = "sdkuser";
     public static String PASSWORD = "password";
     public static String USER_EMAIL = "sdkuser@example.com";
@@ -32,5 +43,79 @@ public abstract class AndroidBaseTest {
     public void setUpSDK() {
         Logger.set(Logger.Level.DEBUG);
         FRAuth.start(context);
+    }
+
+    /**
+     * Register a random user
+     *
+     * @return The username of the registered user
+     * @throws ExecutionException
+     * @throws InterruptedException
+     */
+    public static String registerRandomUser() throws ExecutionException, InterruptedException {
+        String randomUsername = "user" + System.currentTimeMillis();
+
+        NodeListenerFuture<FRSession> nodeListenerFuture = getNodeListenerFuture(randomUsername);
+
+        FRSession.authenticate(context, "TEST_USER_REGISTRATION", nodeListenerFuture);
+        Assert.assertNotNull(nodeListenerFuture.get());
+        Assert.assertNotNull(FRSession.getCurrentSession());
+        Assert.assertNotNull(FRSession.getCurrentSession().getSessionToken());
+
+        return randomUsername;
+    }
+
+    protected static NodeListenerFuture<FRSession> getNodeListenerFuture(String userName) {
+        return new UsernamePasswordNodeListener(context) {
+            @Override
+            public void onCallbackReceived(Node node) {
+                if (node.getCallback(NameCallback.class) != null) {
+                    node.getCallback(NameCallback.class).setName(userName);
+                    node.next(context, this);
+                }
+                if (node.getCallback(PasswordCallback.class) != null) {
+                    PasswordCallback callback = node.getCallback(PasswordCallback.class);
+                    assertThat(callback.getPrompt()).isEqualTo("Password");
+                    callback.setPassword(userName.toCharArray());
+                    node.next(context, this );
+                }
+                if (node.getCallback(StringAttributeInputCallback.class) != null) {
+                    List<Callback> callbacks = node.getCallbacks();
+
+                    StringAttributeInputCallback givenName = (StringAttributeInputCallback) callbacks.get(0);
+                    StringAttributeInputCallback sn = (StringAttributeInputCallback) callbacks.get(1);
+                    StringAttributeInputCallback mail = (StringAttributeInputCallback) callbacks.get(2);
+
+                    givenName.setValue(userName);
+                    sn.setValue(userName);
+                    mail.setValue(userName +  "@example.com");
+
+                    node.next(context, this );
+                }
+                if (node.getCallback(KbaCreateCallback.class) != null) {
+                    List<Callback> callbacks = node.getCallbacks();
+
+                    KbaCreateCallback firstQuestion = (KbaCreateCallback) callbacks.get(0);
+                    firstQuestion.setSelectedQuestion(firstQuestion.getPredefinedQuestions().get(0));
+                    firstQuestion.setSelectedAnswer("Test");
+
+                    // Uncomment this block if there are more than one KbaCreateCallbacks in the tree
+                    /*
+                    KbaCreateCallback secondQuestion = (KbaCreateCallback) callbacks.get(1);
+                    secondQuestion.setSelectedQuestion(secondQuestion.getPredefinedQuestions().get(1));
+                    secondQuestion.setSelectedAnswer("Test");
+                    */
+
+                    node.next(context, this );
+                }
+
+                if (node.getCallback(TermsAndConditionsCallback.class) != null) {
+                    TermsAndConditionsCallback callback = node.getCallback(TermsAndConditionsCallback.class);
+                    callback.setAccept(true);
+
+                    node.next(context, this );
+                }
+            }
+        };
     }
 }

--- a/forgerock-integration-tests/src/androidTest/java/org/forgerock/android/auth/FRDeviceProfileTest.java
+++ b/forgerock-integration-tests/src/androidTest/java/org/forgerock/android/auth/FRDeviceProfileTest.java
@@ -22,7 +22,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.SdkSuppress;
 import androidx.test.rule.GrantPermissionRule;
 
-import org.forgerock.android.auth.callback.DeviceProfileCollectorCallbackAndroidTest;
 import org.forgerock.android.auth.collector.BluetoothCollector;
 import org.forgerock.android.auth.collector.DeviceCollector;
 import org.forgerock.android.auth.collector.FRDeviceCollector;
@@ -47,6 +46,9 @@ public class FRDeviceProfileTest extends AndroidBaseTest {
             Manifest.permission.ACCESS_BACKGROUND_LOCATION,
             Manifest.permission.BLUETOOTH
     );
+
+    @Rule
+    public SkipTestOnPermissionFailureRule skipRule = new SkipTestOnPermissionFailureRule();
 
     @Before
     public void setUp() throws Exception {
@@ -175,9 +177,6 @@ public class FRDeviceProfileTest extends AndroidBaseTest {
         result.get().getJSONObject("telephony").getString("networkCountryIso");
 
     }
-
-
-
 
     private boolean isEmulator() {
         return Build.PRODUCT.matches(".*_?sdk_?.*");

--- a/forgerock-integration-tests/src/androidTest/java/org/forgerock/android/auth/FRDeviceProfileTest.java
+++ b/forgerock-integration-tests/src/androidTest/java/org/forgerock/android/auth/FRDeviceProfileTest.java
@@ -132,6 +132,7 @@ public class FRDeviceProfileTest extends AndroidBaseTest {
 
         if (!isEmulator() && locationPermissionGranted) {
             Logger.debug(TAG, "Location data should exist!");
+            Logger.debug(TAG, result.toString());
             assertTrue(result.getJSONObject("location").has("latitude"));
             assertTrue(result.getJSONObject("location").has("longitude"));
         }
@@ -175,7 +176,6 @@ public class FRDeviceProfileTest extends AndroidBaseTest {
         collector.collect(context, result);
         result.get().getJSONObject("bluetooth").getBoolean("supported");
         result.get().getJSONObject("telephony").getString("networkCountryIso");
-
     }
 
     private boolean isEmulator() {

--- a/forgerock-integration-tests/src/androidTest/java/org/forgerock/android/auth/RetryTestRule.java
+++ b/forgerock-integration-tests/src/androidTest/java/org/forgerock/android/auth/RetryTestRule.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024 ForgeRock. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package org.forgerock.android.auth;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class RetryTestRule implements TestRule {
+    private int retryCount;
+
+    public RetryTestRule(int retryCount) {
+        this.retryCount = retryCount;
+    }
+
+    public Statement apply(Statement base, Description description) {
+        return statement(base, description);
+    }
+
+    private Statement statement(final Statement base, final Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                Throwable caughtThrowable = null;
+
+                for (int i = 0; i < retryCount; i++) {
+                    try {
+                        base.evaluate();
+                        return;
+                    } catch (Throwable t) {
+                        caughtThrowable = t;
+                        System.err.println(description.getDisplayName() + ": run " + (i + 1) + " failed");
+                    }
+                }
+                System.err.println(description.getDisplayName() + ": giving up after " + retryCount + " failures");
+                throw caughtThrowable;
+            }
+        };
+    }
+}

--- a/forgerock-integration-tests/src/androidTest/java/org/forgerock/android/auth/SkipTestOnPermissionFailureRule.java
+++ b/forgerock-integration-tests/src/androidTest/java/org/forgerock/android/auth/SkipTestOnPermissionFailureRule.java
@@ -1,0 +1,28 @@
+package org.forgerock.android.auth;
+
+import org.junit.AssumptionViolatedException;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import junit.framework.AssertionFailedError;
+
+public class SkipTestOnPermissionFailureRule implements TestRule {
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                try {
+                    base.evaluate();
+                } catch (AssertionFailedError e) {
+                    if (e.getMessage().contains("Failed to grant permissions")) {
+                        throw new AssumptionViolatedException("Skipping test due to failure to grant permissions");
+                    } else {
+                        throw e; // Re-throw other AssertionFailedError
+                    }
+                }
+            }
+        };
+    }
+}

--- a/forgerock-integration-tests/src/androidTest/java/org/forgerock/android/auth/callback/BaseDeviceBindingTest.java
+++ b/forgerock-integration-tests/src/androidTest/java/org/forgerock/android/auth/callback/BaseDeviceBindingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2023 - 2024 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -7,24 +7,29 @@
 
 package org.forgerock.android.auth.callback;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.forgerock.android.auth.devicebind.LocalDeviceBindingRepositoryKt.ORG_FORGEROCK_V_1_DEVICE_REPO;
 
 import android.content.Context;
 
 import androidx.test.core.app.ApplicationProvider;
 
+import org.forgerock.android.auth.AndroidBaseTest;
 import org.forgerock.android.auth.EncryptedPreferences;
 import org.forgerock.android.auth.FRAuth;
 import org.forgerock.android.auth.FROptions;
 import org.forgerock.android.auth.FROptionsBuilder;
 import org.forgerock.android.auth.FRSession;
 import org.forgerock.android.auth.Logger;
+import org.forgerock.android.auth.RetryTestRule;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.Timeout;
 
+import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 public abstract class BaseDeviceBindingTest {
@@ -37,7 +42,7 @@ public abstract class BaseDeviceBindingTest {
     protected final static String OAUTH_REDIRECT_URI = "org.forgerock.demo:/oauth2redirect";
     protected final static String SCOPE = "openid profile email address phone";
 
-    protected final static String USERNAME = "sdkuser";
+    protected static String USERNAME = null;
     protected static String KID = null; // Used to store the kid of the key generated during binding
     protected static String USER_ID = null; // Used to store the userId of the user who binds the device
 
@@ -70,6 +75,15 @@ public abstract class BaseDeviceBindingTest {
         FRAuth.start(context, options);
         // Clear all preexisting registered keys on the device
         EncryptedPreferences.Companion.getInstance(context, ORG_FORGEROCK_V_1_DEVICE_REPO).edit().clear().apply();
+
+        // Register a random user. This is needed to avoid test failure when tests are run in parallel on multiple devices
+        try {
+            USERNAME = AndroidBaseTest.registerRandomUser();
+        } catch (ExecutionException e) {
+            fail("Failed to register a new random user: ", e);
+        } catch (InterruptedException e) {
+            fail("Failed to register a new random user: ", e);
+        }
     }
 
     @After

--- a/forgerock-integration-tests/src/androidTest/java/org/forgerock/android/auth/callback/DeviceBindingNodeListener.java
+++ b/forgerock-integration-tests/src/androidTest/java/org/forgerock/android/auth/callback/DeviceBindingNodeListener.java
@@ -7,7 +7,7 @@
 
 package org.forgerock.android.auth.callback;
 
-import static org.forgerock.android.auth.AndroidBaseTest.USERNAME;
+import static org.forgerock.android.auth.callback.BaseDeviceBindingTest.USERNAME;
 
 import android.content.Context;
 

--- a/forgerock-integration-tests/src/androidTest/java/org/forgerock/android/auth/callback/DeviceProfileCollectorCallbackAndroidTest.java
+++ b/forgerock-integration-tests/src/androidTest/java/org/forgerock/android/auth/callback/DeviceProfileCollectorCallbackAndroidTest.java
@@ -7,19 +7,14 @@
 
 package org.forgerock.android.auth.callback;
 
-import static android.Manifest.permission.ACCESS_COARSE_LOCATION;
-import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import android.Manifest;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.location.LocationManager;
 import android.os.Build;
-import android.os.Process;
-import android.util.Log;
 
 import androidx.core.app.ActivityCompat;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -29,6 +24,7 @@ import androidx.test.rule.GrantPermissionRule;
 import org.forgerock.android.auth.AndroidBaseTest;
 import org.forgerock.android.auth.FRListenerFuture;
 import org.forgerock.android.auth.Logger;
+import org.forgerock.android.auth.SkipTestOnPermissionFailureRule;
 import org.json.JSONObject;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,6 +42,9 @@ public class DeviceProfileCollectorCallbackAndroidTest extends AndroidBaseTest {
             Manifest.permission.ACCESS_BACKGROUND_LOCATION,
             Manifest.permission.BLUETOOTH
     );
+
+    @Rule
+    public SkipTestOnPermissionFailureRule skipRule = new SkipTestOnPermissionFailureRule();
 
     @Test
     public void testMetadata() throws Exception {

--- a/forgerock-integration-tests/src/androidTest/java/org/forgerock/android/auth/callback/DeviceProfileCollectorCallbackAndroidTest.java
+++ b/forgerock-integration-tests/src/androidTest/java/org/forgerock/android/auth/callback/DeviceProfileCollectorCallbackAndroidTest.java
@@ -23,7 +23,9 @@ import androidx.test.rule.GrantPermissionRule;
 
 import org.forgerock.android.auth.AndroidBaseTest;
 import org.forgerock.android.auth.FRListenerFuture;
+import org.forgerock.android.auth.Log;
 import org.forgerock.android.auth.Logger;
+import org.forgerock.android.auth.RetryTestRule;
 import org.forgerock.android.auth.SkipTestOnPermissionFailureRule;
 import org.json.JSONObject;
 import org.junit.Rule;
@@ -147,6 +149,7 @@ public class DeviceProfileCollectorCallbackAndroidTest extends AndroidBaseTest {
 
         if (!isEmulator() && locationPermissionGranted) {
             Logger.debug(TAG, "Location data should exist!");
+            Logger.debug(TAG, content);
             assertTrue(content.contains("location"));
         }
     }

--- a/forgerock-integration-tests/src/androidTest/java/org/forgerock/android/auth/callback/KeyAttestationTest.java
+++ b/forgerock-integration-tests/src/androidTest/java/org/forgerock/android/auth/callback/KeyAttestationTest.java
@@ -13,6 +13,7 @@ import android.os.Build;
 
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.SdkSuppress;
 
 import com.nimbusds.jose.util.Base64;
 import com.nimbusds.jwt.JWT;
@@ -37,6 +38,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 @RunWith(AndroidJUnit4.class)
+@SdkSuppress(minSdkVersion = Build.VERSION_CODES.N)  // Key Attestation is only supported on Android 7.0 (API level 24) and above...
 public class KeyAttestationTest extends BaseDeviceBindingTest {
     protected final static String TREE = "key-attestation";
 
@@ -417,7 +419,6 @@ public class KeyAttestationTest extends BaseDeviceBindingTest {
         assertThat(unsupportedOutcome[0]).isEqualTo(1);
         assertThat(executionExceptionOccurred).isTrue();
     }
-
 }
 
 


### PR DESCRIPTION
# JIRA Ticket

[SDKS-3015](https://bugster.forgerock.org/jira/browse/SDKS-3015) SDK 4.4.0 Release Testing

# Description
Some of the device binding/signing e2e test cases were failing when running in parallel on multiple devices, because they were using the same user and some assumptions were not met - for example, some a test may make the user inactive, and at the same time, other tests assume/require that the same user is active...
For that reason, I introduced the following improvements: 
- All device binding/signing related test cases now create a brand new random user...
- Introduced a `RetryTestRule` annotation and added it to the device binding tests. This way a test would be repeated 3 times if it fails... This is useful for flaky tests...
- "Suppressed" the `KeyAttestation` e2e test cases on Android 6, since this feature is not available on this version... 
- Added `SkipTestOnPermissionFailureRule` to the device location-related tests. This helps in some cases and I see that this works as expected... Nevertheless, there are still rare cases when location data is missing (even though permissions seem to have been granted successfully)...

In general, these measures are a big improvement IMO, but more work is needed...
This is an example [test run](https://cloud.bitbar.com/#testing/device-session/207366434/211529522) on BitBar, with the proposed changes on all supported Android versions (6 to 14)... As you can see on Android 7 and 8 we still have some tests failing... :-( 

<img width="1566" alt="image" src="https://github.com/ForgeRock/forgerock-android-sdk/assets/1580960/02d6adac-9ba8-493b-b9b0-aaf76973f1ae">

