### PR TITLE
Make ActivityNotFoundException to be intercepted by FRListener

### DIFF
--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/AppAuthFragment.java
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/AppAuthFragment.java
@@ -92,7 +92,7 @@ public class AppAuthFragment extends Fragment {
             startActivityForResult(intent, AUTH_REQUEST_CODE);
         } catch (ActivityNotFoundException e) {
             if (browser.isFailedOnNoBrowserFound()) {
-                throw e;
+                Listener.onException(browser.listener, e);
             }
         }
     }

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/AppAuthFragment.java
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/AppAuthFragment.java
@@ -92,7 +92,7 @@ public class AppAuthFragment extends Fragment {
             startActivityForResult(intent, AUTH_REQUEST_CODE);
         } catch (ActivityNotFoundException e) {
             if (browser.isFailedOnNoBrowserFound()) {
-                Listener.onException(browser.listener, e);
+                Listener.onException(browser.getListener(), e);
             }
         }
     }

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/FRUser.java
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/FRUser.java
@@ -259,7 +259,7 @@ public class FRUser {
     @Getter(AccessLevel.PACKAGE)
     public static class Browser {
 
-        private FRListener<AuthorizationResponse> listener;
+        public FRListener<AuthorizationResponse> listener;
         private AppAuthConfigurer appAuthConfigurer = new AppAuthConfigurer(this);
         private boolean failedOnNoBrowserFound = true;
 

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/BrowserLoginTest.kt
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/BrowserLoginTest.kt
@@ -351,6 +351,38 @@ class BrowserLoginTest : BaseTest() {
         Assertions.assertThat(result["END_SESSION"]?.second).isEqualTo(1)
     }
 
+    @Test
+    fun testActivityNotFound() {
+        val scenario: ActivityScenario<DummyActivity> =
+            ActivityScenario.launch(DummyActivity::class.java)
+        scenario.onActivity {
+            InitProvider.setCurrentActivity(it)
+        }
+        val future = FRListenerFuture<FRUser>()
+        scenario.onActivity {
+            FRUser.browser().failedOnNoBrowserFound(true)
+                .login(it, future)
+        }
+
+        val intent = Intent()
+        intent.putExtra(
+            AuthorizationResponse.EXTRA_RESPONSE,
+            "{\"request\":{\"configuration\":{\"authorizationEndpoint\":\"http:\\/\\/openam.example.com:8081\\/openam\\/oauth2\\/realms\\/root\\/authorize\",\"tokenEndpoint\":\"http:\\/\\/openam.example.com:8081\\/openam\\/oauth2\\/realms\\/root\\/access_token\"},\"clientId\":\"AndroidTest\",\"responseType\":\"code\",\"redirectUri\":\"net.openid.appauthdemo2:\\/oauth2redirect\",\"login_hint\":\"login\",\"scope\":\"openid profile email address phone\",\"state\":\"2v0SIhB7UAmsqvnvwR-IKQ\",\"codeVerifier\":\"qvCFoo3tqB-89lYOFjX2ZAMalkKgW_KIcc1tN3hmx3ygOHyYbWT9hKU7rhky6ivB-33exlhyyHHeSJtuVfOobg\",\"codeVerifierChallenge\":\"i-UW4h0UlD_pt1WCYGeP6prmtOkXhyQB_s1itrkV68k\",\"codeVerifierChallengeMethod\":\"S256\",\"additionalParameters\":{}},\"state\":\"2v0SIhB7UAmsqvnvwR-IKQ\",\"code\":\"roxwkG0TtooR2vzA6z0MT9xyJSQ\",\"additional_parameters\":{\"iss\":\"http:\\/\\/openam.example.com:8081\\/openam\\/oauth2\",\"client_id\":\"andy_app\"}}"
+        )
+        scenario.onActivity {
+            getAppAuthFragment(it)?.onActivityResult(
+                AppAuthFragment.AUTH_REQUEST_CODE, Activity.RESULT_OK, intent
+            )
+        }
+
+        try {
+            future.get()
+            Assert.fail()
+        } catch (e: ExecutionException) {
+            Assertions.assertThat(e.cause).isInstanceOf(ActivityNotFoundException::class.java)
+        }
+    }
+
     private fun parse(encoded: String): Map<String, String> {
         val body = encoded.split("&").toTypedArray()
         val result: MutableMap<String, String> = HashMap()


### PR DESCRIPTION
# JIRA Ticket

N/A

# Description

Hello Forgerock team!

On our project, we've encountered an issue when android app is crashing with the following stack trace:
```
android.content.ActivityNotFoundException
  at net.openid.appauth.AuthorizationService.prepareAuthorizationRequestIntent(AuthorizationService.java:555)
  at net.openid.appauth.AuthorizationService.getAuthorizationRequestIntent(AuthorizationService.java:390)
  at org.forgerock.android.auth.AppAuthFragment.onCreate(AppAuthFragment.java:90)
  at androidx.fragment.app.Fragment.performCreate(Fragment.java:3094)
  at androidx.fragment.app.FragmentStateManager.create(FragmentStateManager.java:504)
  at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:268)
  at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:1943)
  at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:1839)
  at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:1782)
  at androidx.fragment.app.FragmentManager$5.run(FragmentManager.java:565)
  at android.os.Handler.handleCallback(Handler.java:942)
  at android.os.Handler.dispatchMessage(Handler.java:99)
  at android.os.Looper.loopOnce(Looper.java:226)
  at android.os.Looper.loop(Looper.java:313)
  at android.app.ActivityThread.main(ActivityThread.java:8762)
  at java.lang.reflect.Method.invoke(Method.java)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:604)
  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
```

We still don't know the exact root cause of the crash, but we were able to reproduce it by removing/disabling all installed browsers(I appreciate that it's unlikely the real cause thought)

The changes I made are most probably not the right way to fix the problem, but at least it should allow to handle the exception gracefully.

Ideally(for our particular case), it should be: exception intercepted -> try to open an external browser to proceed with centralized login.

Therefore, I also have a question: Is it possible to get the built URL that should be opened in the browser? Since we have a react-native app and custom JS wrapper around FR SDK, it would be convenient to send the callback, like "onFailedToOpenCustomTabs," with the URL to be opened as an argument.

Thanks
