### PR TITLE
SDKS-3180 Add Jacoco test coverage report

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -10,6 +10,9 @@ on:
       SLACK_WEBHOOK:
         description: Slack Notifier Incoming Webhook
         required: true
+      CODECOV_TOKEN:
+        description: Codecov token
+        required: true
 jobs:
   build-and-test:
     runs-on: ${{ inputs.runs-on }}
@@ -31,21 +34,21 @@ jobs:
           java-version: '17'
           cache: 'gradle'
 
-      # Execute forgerock-core debug unit tests
+      # Execute forgerock-core debug unit tests with coverage report
       - name: Run forgerock-core debug unit tests
-        run: ./gradlew :forgerock-core:testDebugUnitTest --stacktrace --no-daemon
+        run: ./gradlew :forgerock-core:testDebugUnitTestCoverage --stacktrace --no-daemon
         
-      # Execute forgerock-auth debug unit tests
+      # Execute forgerock-auth debug unit tests with coverage report
       - name: Run forgerock-auth debug unit tests
-        run: ./gradlew :forgerock-auth:testDebugUnitTest --stacktrace --no-daemon
+        run: ./gradlew :forgerock-auth:testDebugUnitTestCoverage --stacktrace --no-daemon
 
-      # Execute forgerock-authenticator debug unit tests
+      # Execute forgerock-authenticator debug unit tests with coverage report
       - name: Run forgerock-authenticator debug unit tests
-        run: ./gradlew :forgerock-authenticator:testDebugUnitTest --stacktrace --no-daemon
+        run: ./gradlew :forgerock-authenticator:testDebugUnitTestCoverage --stacktrace --no-daemon
 
-      # Execute forgerock-authenticator debug unit tests
+      # Execute forgerock-authenticator debug unit tests with coverage report
       - name: Run ping-protect debug unit tests
-        run: ./gradlew :ping-protect:testDebugUnitTest --stacktrace --no-daemon
+        run: ./gradlew :ping-protect:testDebugUnitTestCoverage --stacktrace --no-daemon
 
       # Publish test reports for the unit tests
       - name: Publish test results
@@ -59,7 +62,14 @@ jobs:
           fail-on-error: 'true'
           reporter: java-junit
 
-      # Send slack notification with result status
+      # Upload coverage reports to Codecov
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: forgerock-core/build/coverage-report/test-coverage.xml, forgerock-auth/build/coverage-report/test-coverage.xml, forgerock-authenticator/build/coverage-report/test-coverage.xml, ping-protect/build/coverage-report/test-coverage.xml
+          flags: unit-tests
+
       - uses: 8398a7/action-slack@v3
         with:
           mention: 'stoyan.petrov,andy.witrisna,jey.periyasamy'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,7 @@ jobs:
     uses: ./.github/workflows/build-and-test.yaml
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   # Run Mend CLI Scan
   mend-cli-scan:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/ForgeRock/forgerock-android-sdk?color=%23f46200&label=Version&style=flat-square)](CHANGELOG.md)
 [![Build Status](https://github.com/ForgeRock/forgerock-android-sdk/actions/workflows/ci.yaml/badge.svg)](https://github.com/ForgeRock/forgerock-android-sdk/actions/workflows/ci.yaml)
+[![Coverage](https://codecov.io/gh/ForgeRock/forgerock-android-sdk/graph/badge.svg?token=PGfmkaLyIC)](https://codecov.io/gh/ForgeRock/forgerock-android-sdk)
 
 <p align="center">
   <a href="https://github.com/ForgeRock">

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,9 +103,9 @@ subprojects {
 
 
     tasks.withType<Test>().configureEach {
-        jvmArgs = jvmArgs?.plus("--add-opens=java.base/java.lang=ALL-UNNAMED")
-        jvmArgs = jvmArgs?.plus("--add-opens=java.base/java.security=ALL-UNNAMED")
-        jvmArgs = jvmArgs?.plus("--add-opens=java.base/java.security.cert=ALL-UNNAMED")
+        jvmArgs = jvmArgs?.plus("--add-opens=java.base/java.lang=ALL-UNNAMED") as MutableList<String>
+        jvmArgs = jvmArgs?.plus("--add-opens=java.base/java.security=ALL-UNNAMED") as MutableList<String>
+        jvmArgs = jvmArgs?.plus("--add-opens=java.base/java.security.cert=ALL-UNNAMED") as MutableList<String>
     }
 
 }

--- a/config/jacoco.gradle
+++ b/config/jacoco.gradle
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 ForgeRock. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+apply plugin: 'jacoco'
+
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+tasks.withType(Test) {
+    // see related issue https://github.com/gradle/gradle/issues/5184#issuecomment-457865951
+    jacoco.includeNoLocationClasses = true
+    jacoco.excludes = ['jdk.internal.*']
+}
+
+task testDebugUnitTestCoverage(type: JacocoReport, dependsOn: 'testDebugUnitTest') {
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+
+        html.destination file("${buildDir}/coverage-report")
+        xml.destination file("${buildDir}/coverage-report/test-coverage.xml")
+    }
+
+    // Setup the .class, source, and execution directories
+    final fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', 'android/**/*.*']
+    final kotlinTree = fileTree(dir: "${project.buildDir}/tmp/kotlin-classes/debug", excludes: fileFilter)
+    final javacTree = fileTree(dir: "${project.buildDir}/intermediates/javac/debug", excludes: fileFilter)
+    final mainSrc = "${project.projectDir}/src/main/java"
+
+    sourceDirectories.setFrom files([mainSrc])
+    classDirectories.setFrom files([kotlinTree, javacTree])
+    executionData.setFrom fileTree(dir: project.buildDir, includes: [
+            'jacoco/testDebugUnitTest.exec', 'outputs/code-coverage/connected/*coverage.ec'
+    ])
+}

--- a/forgerock-auth/build.gradle.kts
+++ b/forgerock-auth/build.gradle.kts
@@ -38,6 +38,7 @@ android {
 
 }
 
+apply("../config/jacoco.gradle")
 apply("../config/logger.gradle")
 apply("../config/kdoc.gradle")
 apply("../config/publish.gradle")

--- a/forgerock-authenticator/build.gradle.kts
+++ b/forgerock-authenticator/build.gradle.kts
@@ -50,6 +50,7 @@ tasks {
     }
 }
 
+apply("../config/jacoco.gradle")
 apply("../config/logger.gradle")
 apply("../config/publish.gradle")
 

--- a/forgerock-core/build.gradle.kts
+++ b/forgerock-core/build.gradle.kts
@@ -45,6 +45,7 @@ android {
 
 }
 
+apply("../config/jacoco.gradle")
 apply("../config/logger.gradle")
 apply("../config/kdoc.gradle")
 apply("../config/publish.gradle")

--- a/ping-protect/build.gradle.kts
+++ b/ping-protect/build.gradle.kts
@@ -49,6 +49,7 @@ tasks {
     }
 }
 
+apply("../config/jacoco.gradle")
 apply("../config/logger.gradle")
 apply("../config/publish.gradle")
 


### PR DESCRIPTION
# JIRA Ticket

[SDKS-3180](https://bugster.forgerock.org/jira/browse/SDKS-3180) Add test coverage report to Android SDK pipeline

# Description
- Added test coverage report to the `forgerock-core`, `forgerock-auth`, `forgerock-authenticator`, and `ping-protect` modules