### PR TITLE
SDKS-3073 Resolve commons-io-2.6.jar and bcprov-jdk15on-1.68.jar vulnerability warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.4.2]
+#### Fixed
+- SDKS-3073 Resolve commons-io-2.6.jar and bcprov-jdk15on-1.68.jar vulnerability warning [SDKS-3073]
+
 ## [4.4.1]
 #### Fixed
 - Synchronize the encryption and decryption block to avoid keystore crash [SDKS-3199]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,8 +64,6 @@ allprojects {
             //Due to this https://github.com/powermock/powermock/issues/1125, we have to keep using an
             //older version of mockito until mockito release a fix
             force("org.mockito:mockito-core:3.12.4")
-            // this is for the mockwebserver
-            force("org.bouncycastle:bcprov-jdk15on:1.68")
         }
     }
 }

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/AuthServiceMockTest.java
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/AuthServiceMockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2022 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 - 2024 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -8,9 +8,6 @@
 package org.forgerock.android.auth;
 
 import android.net.Uri;
-
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 import org.forgerock.android.auth.callback.AbstractPromptCallback;
 import org.forgerock.android.auth.callback.CallbackFactory;
@@ -34,6 +31,9 @@ import java.util.concurrent.ExecutionException;
 
 import static java.util.Collections.emptyMap;
 import static org.junit.Assert.*;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
 
 @RunWith(RobolectricTestRunner.class)
 public class AuthServiceMockTest extends BaseTest {

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/BaseTest.java
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/BaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 - 2024 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -11,8 +11,6 @@ import android.content.Context;
 
 import androidx.test.core.app.ApplicationProvider;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
@@ -23,6 +21,9 @@ import org.robolectric.shadows.ShadowLog;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 public class BaseTest {
 

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/BrowserLoginTest.kt
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/BrowserLoginTest.kt
@@ -17,9 +17,9 @@ import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
-import com.squareup.okhttp.mockwebserver.MockResponse
-import com.squareup.okhttp.mockwebserver.RecordedRequest
 import net.openid.appauth.*
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.RecordedRequest
 import org.assertj.core.api.Assertions
 import org.forgerock.android.auth.exception.AlreadyAuthenticatedException
 import org.forgerock.android.auth.exception.ApiException
@@ -406,7 +406,7 @@ class BrowserLoginTest : BaseTest() {
         vararg recordedRequests: RecordedRequest
     ): RecordedRequest {
         for (r in recordedRequests) {
-            if (r.path.startsWith(path)) {
+            if (r.path!!.startsWith(path)) {
                 return r
             }
         }

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/DefaultTokenManagerTest.kt
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/DefaultTokenManagerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 - 2024 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -8,7 +8,7 @@ package org.forgerock.android.auth
 
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.squareup.okhttp.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockResponse
 import org.forgerock.android.auth.exception.AuthenticationRequiredException
 import org.forgerock.android.auth.exception.InvalidGrantException
 import org.junit.After

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/DeviceBindingRepositoryTest.kt
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/DeviceBindingRepositoryTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 - 2023  ForgeRock. All rights reserved.
+ * Copyright (c) 2022 - 2024  ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -7,9 +7,9 @@
 package org.forgerock.android.auth
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.squareup.okhttp.mockwebserver.MockResponse
 import junit.framework.Assert.fail
 import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
 import org.assertj.core.api.Assertions.assertThat
 import org.forgerock.android.auth.callback.DeviceBindingAuthenticationType
 import org.forgerock.android.auth.devicebind.DeviceBindingRepository

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/FRAuthMockTest.java
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/FRAuthMockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 - 2024 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -18,8 +18,6 @@ import android.content.res.Resources;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
-
 import org.forgerock.android.auth.callback.NameCallback;
 import org.forgerock.android.auth.callback.PasswordCallback;
 import org.forgerock.android.auth.exception.AuthenticationRequiredException;
@@ -33,6 +31,8 @@ import org.mockito.Mockito;
 import java.net.HttpURLConnection;
 import java.util.Collections;
 import java.util.concurrent.ExecutionException;
+
+import okhttp3.mockwebserver.RecordedRequest;
 
 @RunWith(AndroidJUnit4.class)
 public class FRAuthMockTest extends BaseTest {

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/FRAuthRegistrationMockTest.kt
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/FRAuthRegistrationMockTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2023 - 2024 ForgeRock. All rights reserved.
  *
  *  This software may be modified and distributed under the terms
  *  of the MIT license. See the LICENSE file for details.
@@ -9,7 +9,7 @@ package org.forgerock.android.auth
 import android.content.Context
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.squareup.okhttp.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockResponse
 import org.assertj.core.api.Assertions.*
 import org.forgerock.android.auth.callback.BooleanAttributeInputCallback
 import org.forgerock.android.auth.callback.KbaCreateCallback

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/FRLifeCycleListenerTest.kt
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/FRLifeCycleListenerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2023 -2024 ForgeRock. All rights reserved.
  *
  *  This software may be modified and distributed under the terms
  *  of the MIT license. See the LICENSE file for details.
@@ -9,7 +9,7 @@ package org.forgerock.android.auth
 import android.content.Context
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.squareup.okhttp.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockResponse
 import org.assertj.core.api.Assertions
 import org.forgerock.android.auth.callback.NameCallback
 import org.forgerock.android.auth.callback.PasswordCallback

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/FRSessionMockTest.java
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/FRSessionMockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 - 2024 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -12,8 +12,6 @@ import android.net.Uri;
 import android.os.OperationCanceledException;
 import android.util.Pair;
 
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
-
 import org.forgerock.android.auth.callback.NameCallback;
 import org.forgerock.android.auth.callback.PasswordCallback;
 import org.forgerock.android.auth.callback.SuspendedTextOutputCallback;
@@ -22,7 +20,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import java.net.HttpURLConnection;
 import java.util.HashMap;
@@ -33,6 +30,8 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.forgerock.android.auth.Action.AUTHENTICATE;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import okhttp3.mockwebserver.RecordedRequest;
 
 @RunWith(AndroidJUnit4.class)
 public class FRSessionMockTest extends BaseTest {

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/FRUserMockTest.java
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/FRUserMockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 - 2024 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -25,9 +25,6 @@ import android.net.Uri;
 import android.util.Pair;
 
 import androidx.annotation.NonNull;
-
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 import org.assertj.core.api.Assertions;
 import org.forgerock.android.auth.callback.Callback;
@@ -65,6 +62,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 
 import okhttp3.Cookie;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
 
 @RunWith(RobolectricTestRunner.class)
 public class FRUserMockTest extends BaseTest {

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/OAuth2MockTest.java
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/OAuth2MockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2022 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 - 2024 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -8,9 +8,6 @@
 package org.forgerock.android.auth;
 
 import android.net.Uri;
-
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 import org.assertj.core.api.Assertions;
 import org.forgerock.android.auth.exception.ApiException;
@@ -27,6 +24,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
 
 @RunWith(RobolectricTestRunner.class)
 public class OAuth2MockTest extends BaseTest {

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/PersistentCookieTest.java
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/PersistentCookieTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 - 2024 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -7,13 +7,9 @@
 
 package org.forgerock.android.auth;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import java.net.HttpURLConnection;
 import java.util.HashMap;
@@ -26,6 +22,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import android.content.Context;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
 
 @RunWith(AndroidJUnit4.class)
 public class PersistentCookieTest extends BaseTest {

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/PolicyAdviceTest.kt
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/PolicyAdviceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 - 2024 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -10,12 +10,12 @@ import android.content.Context
 import android.net.Uri
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.squareup.okhttp.mockwebserver.MockResponse
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
+import okhttp3.mockwebserver.MockResponse
 import org.assertj.core.api.Assertions
 import org.forgerock.android.auth.PolicyAdvice.Companion.parse
 import org.forgerock.android.auth.interceptor.AdviceHandler

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/SSOBroadcastReceiverIntegrationTests.kt
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/SSOBroadcastReceiverIntegrationTests.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 - 2023 ForgeRock. All rights reserved.
+ *  Copyright (c) 2022 - 2024 ForgeRock. All rights reserved.
  *
  *  This software may be modified and distributed under the terms
  *  of the MIT license. See the LICENSE file for details.
@@ -11,10 +11,9 @@ package org.forgerock.android.auth
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import com.squareup.okhttp.mockwebserver.Dispatcher
-import com.squareup.okhttp.mockwebserver.MockResponse
-import com.squareup.okhttp.mockwebserver.RecordedRequest
-import org.assertj.core.api.Assertions.*
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.RecordedRequest
 import org.forgerock.android.auth.callback.NameCallback
 import org.forgerock.android.auth.callback.PasswordCallback
 import org.junit.Assert.*
@@ -22,7 +21,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.net.HttpURLConnection
-import java.util.*
 import java.util.concurrent.CountDownLatch
 
 @RunWith(RobolectricTestRunner::class)
@@ -33,7 +31,7 @@ class SSOBroadcastReceiverIntegrationTests: BaseTest() {
 
     private fun findRequest(path: String, vararg recordedRequests: RecordedRequest): RecordedRequest {
         for (r: RecordedRequest in recordedRequests) {
-            if (r.path.startsWith(path)) {
+            if (r.path!!.startsWith(path)) {
                 return r
             }
         }
@@ -78,7 +76,7 @@ class SSOBroadcastReceiverIntegrationTests: BaseTest() {
 
         val request = server.takeRequest();
 
-        val state = Uri.parse(request.getPath()).getQueryParameter("state");
+        val state = Uri.parse(request.path).getQueryParameter("state");
         server.enqueue(MockResponse()
             .addHeader("Location", "http://www.example.com:8080/callback?code=PmxwECH3mBobKuPEtPmq6Xorgzo&iss=http://openam.example.com:8080/openam/oauth2&" +
                     "state=" + state + "&client_id=andy_app")
@@ -104,7 +102,7 @@ class SSOBroadcastReceiverIntegrationTests: BaseTest() {
 
         val latch = CountDownLatch(1)
         val mockHttpDispatcher = MockHttpDispatcher(latch)
-        server.setDispatcher(mockHttpDispatcher)
+        server.dispatcher = mockHttpDispatcher
 
         val accessToken = FRUser.getCurrentUser().accessToken
         assertNotNull(FRUser.getCurrentUser())
@@ -143,7 +141,7 @@ class SSOBroadcastReceiverIntegrationTests: BaseTest() {
 
 private class MockHttpDispatcher(private val latch: CountDownLatch): Dispatcher() {
     val list = mutableListOf<RecordedRequest?>()
-    override fun dispatch(request: RecordedRequest?): MockResponse {
+    override fun dispatch(request: RecordedRequest): MockResponse {
         if(request?.path == "/oauth2/realms/root/token/revoke") {
             list.add(request)
             latch.countDown()
@@ -152,5 +150,6 @@ private class MockHttpDispatcher(private val latch: CountDownLatch): Dispatcher(
             .addHeader("Content-Type", "application/json")
             .setBody("{}")
     }
+
 }
 

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/ServerConfigTest.java
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/ServerConfigTest.java
@@ -80,7 +80,7 @@ public class ServerConfigTest {
         ServerConfig serverConfig = ServerConfig.builder()
                 .context(context)
                 .url("https://api.ipify.org")
-                .pin("Pf/hyG+ywUC8g3d1abF9kQn83lY6NwJUTUnqe03UMIY=")
+                .pin("2lFvaIHpsTcbb5uqa08S2k6wzLKscXXx1k1hKoX9R1Q=")
                 .build();
 
         OkHttpClient client = OkHttpClientProvider.getInstance().lookup(serverConfig);
@@ -122,7 +122,7 @@ public class ServerConfigTest {
         ServerConfig serverConfig = ServerConfig.builder()
                 .context(context)
                 .url("https://api.ipify.org")
-                .pin("Pf/hyG+ywUC8g3d1abF9kQn83lY6NwJUTUnqe03UMIY=")
+                .pin("2lFvaIHpsTcbb5uqa08S2k6wzLKscXXx1k1hKoX9R1Q=")
                 .pin("invalid")
                 .build();
 
@@ -214,7 +214,7 @@ public class ServerConfigTest {
                 .context(context)
                 .url("https://api.ipify.org")
                 .buildStep(builder -> builder.certificatePinner(
-                        new CertificatePinner.Builder().add("api.ipify.org", "sha1/KmdlCymwI4zbla1kcWu2fBEwKA8=" ).build()))
+                        new CertificatePinner.Builder().add("api.ipify.org", "sha1/FAx66BsuUMrmrBnZ8F0GKxBZxLs=" ).build()))
                 .build();
 
         OkHttpClient client = OkHttpClientProvider.getInstance().lookup(serverConfig);

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/SocialLoginTest.java
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/SocialLoginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2021 - 2024 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -28,7 +28,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.android.gms.common.api.ApiException;
 import com.google.android.gms.common.api.Status;
 import com.google.android.gms.common.internal.safeparcel.SafeParcelWriter;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 import org.forgerock.android.auth.callback.CallbackFactory;
 import org.forgerock.android.auth.callback.IdPCallback;
@@ -45,6 +44,8 @@ import org.robolectric.Robolectric;
 import java.net.HttpURLConnection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+
+import okhttp3.mockwebserver.RecordedRequest;
 
 @RunWith(AndroidJUnit4.class)
 public class SocialLoginTest extends BaseTest {

--- a/forgerock-authenticator/build.gradle.kts
+++ b/forgerock-authenticator/build.gradle.kts
@@ -85,7 +85,7 @@ dependencies {
     testImplementation(libs.androidx.test.runner)
     testImplementation(libs.junit)
     testImplementation(libs.org.robolectric.robolectric)
-    testImplementation(libs.okhttp3.mockwebserver)
+    testImplementation(libs.mockwebserver)
     testImplementation(libs.firebase.messaging)
     testImplementation(libs.mockito.core)
 

--- a/forgerock-core/build.gradle.kts
+++ b/forgerock-core/build.gradle.kts
@@ -89,7 +89,6 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.org.robolectric.robolectric)
     testImplementation(libs.mockwebserver)
-    testImplementation(libs.commons.io)
     testImplementation(libs.assertj.core)
 
     testImplementation(libs.bcpkix.jdk15on)

--- a/forgerock-core/src/test/java/org/forgerock/android/auth/NetworkConfigTest.java
+++ b/forgerock-core/src/test/java/org/forgerock/android/auth/NetworkConfigTest.java
@@ -9,8 +9,6 @@ package org.forgerock.android.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.squareup.okhttp.mockwebserver.MockWebServer;
-
 import org.assertj.core.api.Assertions;
 import org.json.JSONException;
 import org.junit.After;
@@ -24,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 
 import okhttp3.CertificatePinner;
 import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockWebServer;
 
 @RunWith(RobolectricTestRunner.class)
 public class NetworkConfigTest {

--- a/forgerock-core/src/test/java/org/forgerock/android/auth/RequestInterceptorTest.java
+++ b/forgerock-core/src/test/java/org/forgerock/android/auth/RequestInterceptorTest.java
@@ -15,10 +15,6 @@ import android.net.Uri;
 
 import androidx.annotation.NonNull;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
-
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -45,6 +41,9 @@ import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
 @RunWith(RobolectricTestRunner.class)
 public class RequestInterceptorTest {

--- a/forgerock-integration-tests/src/androidTest/java/org/forgerock/android/auth/MockServer.java
+++ b/forgerock-integration-tests/src/androidTest/java/org/forgerock/android/auth/MockServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2022 ForgeRock. All rights reserved.
+ * Copyright (c) 2021 - 2024 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -11,15 +11,15 @@ import android.content.Context;
 
 import androidx.test.core.app.ApplicationProvider;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
-
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 /**
  * Mock of AM Server

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ appcompat = "1.6.1"
 assertj-core = "2.9.1"
 bcpkix-jdk15on = "1.58.0.0"
 biometric-ktx = "1.2.0-alpha05"
-commons-io = "2.6"
+commons-io = "2.16.1"
 constraintlayout = "2.1.4"
 easy-random-core = "4.0.0"
 facebook-login = "16.0.0"
@@ -22,8 +22,7 @@ kotlinx-coroutines-play-services = "1.7.2"
 lombok-version = "1.18.28"
 mockito-core = "4.8.1"
 mockito-kotlin = "4.0.0"
-mockwebserver = "2.7.5"
-mockwebserver-version = "4.8.0"
+mockwebserver = "4.12.0"
 nimbus-jose-jwt = "9.37.3"
 okhttp = "4.11.0"
 org-robolectric-robolectric = "4.9.2"
@@ -69,10 +68,9 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockito-kotlin" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito-core" }
-mockwebserver = { module = "com.squareup.okhttp:mockwebserver", version.ref = "mockwebserver" }
+mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver" }
 nimbus-jose-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimbus-jose-jwt" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
-okhttp3-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver-version" }
 org-robolectric-robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "org-robolectric-robolectric" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
 io-mockk = { group = "io.mockk", name = "mockk", version.ref = "io-mockk" }


### PR DESCRIPTION
# JIRA Ticket

[SDKS-3073](https://bugster.forgerock.org/jira/browse/SDKS-3073)
[SDKS-3072](https://bugster.forgerock.org/jira/browse/SDKS-3072)
[SDKS-3215](https://bugster.forgerock.org/jira/browse/SDKS-3215)

# Description

SDKS-3073 Resolve commons-io-2.6.jar and bcprov-jdk15on-1.68.jar vulnerability warning

Upgraded to commons-io = "2.16.1"
The commons-io is only used for testing, no production code is changed.

Remove force("org.bouncycastle:bcprov-jdk15on:1.68") version and upgrade to use okhttp3.mockserver 4.12.0
The org.bouncycastle library is used by mockserver, upgrade the mockserver will also upgrade the bouncycastle
