### PR TITLE
SDKS-3221 uses English locale when generating certificate for Application Pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [4.4.2]
 #### Fixed
-- SDKS-3073 Resolve commons-io-2.6.jar and bcprov-jdk15on-1.68.jar vulnerability warning [SDKS-3073]
+- Resolve commons-io-2.6.jar and bcprov-jdk15on-1.68.jar vulnerability warning [SDKS-3073]
+- Use English locale when generating certificate for Application Pin [SDKS-3221]
 
 ## [4.4.1]
 #### Fixed

--- a/forgerock-core/src/main/java/org/forgerock/android/auth/AppPinAuthenticator.kt
+++ b/forgerock-core/src/main/java/org/forgerock/android/auth/AppPinAuthenticator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 ForgeRock. All rights reserved.
+ * Copyright (c) 2022 - 2024 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -111,6 +111,7 @@ class AppPinAuthenticator(private val cryptoKey: CryptoKey,
             BigInteger.valueOf(System.currentTimeMillis()),
             validityBeginDate,
             validityBeginDate,
+            Locale.ENGLISH,
             owner,
             SubjectPublicKeyInfo.getInstance(keyPair.public.encoded))
         return JcaX509CertificateConverter().getCertificate(builder.build(sigGen))


### PR DESCRIPTION
…

# JIRA Ticket

[SDKS-3221](https://bugster.forgerock.org/jira/browse/SDKS-3221)

# Description

SDKS-3221 uses English locale when generating certificate for Application Pin

![CleanShot 2024-05-22 at 15 28 35](https://github.com/ForgeRock/forgerock-android-sdk/assets/18559472/12621cf6-b214-4360-8722-6372d581a8cb)

