### PR TITLE
SDKS-3244 Only store PublicKeyCredentialSource when requireResidentKey is true

### DIFF
--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/webauthn/FRWebAuthn.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/webauthn/FRWebAuthn.kt
@@ -52,7 +52,8 @@ class FRWebAuthn @JvmOverloads constructor(private val context: Context,
     }
 
     /**
-     * Delete the provide [PublicKeyCredentialSource] from local storage and also remotely from Server.
+     * Delete the provide [PublicKeyCredentialSource] from local storage and also remotely from
+     * Server if the key is discoverable.
      * By default, if failed to delete from server, local storage will not be deleted,
      * by providing [forceDelete] to true, it will also delete local keys if server call is failed.
      * @param publicKeyCredentialSource The [PublicKeyCredentialSource] to be deleted

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/webauthn/WebAuthnRegistration.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/webauthn/WebAuthnRegistration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 - 2024 ForgeRock. All rights reserved.
+ * Copyright (c) 2022 ForgeRock. All rights reserved.
  *
  *  This software may be modified and distributed under the terms
  *  of the MIT license. See the LICENSE file for details.
@@ -156,13 +156,16 @@ open class WebAuthnRegistration() : WebAuthn() {
                 publicKeyCredential.rawId,
                 Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING))
 
-        val source = PublicKeyCredentialSource.builder()
-            .id(publicKeyCredential.rawId)
-            .rpid(options.rp.id)
-            .userHandle(Base64.decode(options.user.id, Base64.URL_SAFE or Base64.NO_WRAP))
-            .otherUI(options.user.displayName).build()
-        persist(context, source)
-
+        //Extension to support username-less
+        if (options.authenticatorSelection?.requireResidentKey == true &&
+            options.authenticatorSelection?.residentKeyRequirement == ResidentKeyRequirement.RESIDENT_KEY_DISCOURAGED) {
+            val source = PublicKeyCredentialSource.builder()
+                .id(publicKeyCredential.rawId)
+                .rpid(options.rp.id)
+                .userHandle(Base64.decode(options.user.id, Base64.URL_SAFE or Base64.NO_WRAP))
+                .otherUI(options.user.displayName).build()
+            persist(context, source)
+        }
         return (sb.toString())
     }
 


### PR DESCRIPTION
# JIRA Ticket

[SDKS-3244](https://bugster.forgerock.org/jira/browse/SDKS-3244) Fix "usernameless" WebAuthn Tests

# Description
This reverts a previous change where the PublicKeyCredentialSource where stored for all WebAuthn use cases.