### PR TITLE
SDKS-3276 & SDKS-3277

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [4.5.0]
 #### Added
 - Support Centralize Oidc Signoff with PingOne [SDKS-3020]
+- The AppAuthConfiguration settings are being ignored during centralized login, causing unexpected behavior in the authentication flow. [SDKS-3277]
 
 #### Fixed
 - Resolve commons-io-2.6.jar and bcprov-jdk15on-1.68.jar vulnerability warning [SDKS-3073]

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/FRUser.java
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/FRUser.java
@@ -19,6 +19,7 @@ import androidx.annotation.WorkerThread;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
+import net.openid.appauth.AppAuthConfiguration;
 import net.openid.appauth.AuthorizationResponse;
 import net.openid.appauth.RedirectUriReceiverActivity;
 
@@ -78,6 +79,20 @@ public class FRUser {
         sessionManager.close();
         FRLifecycle.dispatchLogout();
     }
+
+    /**
+     * Logout the user with specific {@link AppAuthConfiguration}, the {@link AppAuthConfiguration}
+     * should match the configuration used for {@link FRUser.Browser}.
+     * This method should only be used for centralized login.
+     *
+     * @param appAuthConfiguration The AppAuthConfiguration object
+     */
+    public void logout(@NonNull AppAuthConfiguration appAuthConfiguration) {
+        current.set(null);
+        sessionManager.close(appAuthConfiguration);
+        FRLifecycle.dispatchLogout();
+    }
+
 
     /**
      * Revoke the {@link AccessToken} asynchronously,

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/centralize/AuthorizeContract.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/centralize/AuthorizeContract.kt
@@ -72,8 +72,7 @@ internal class AuthorizeContract :
         configurer.customTabsIntentBuilder.accept(intentBuilder)
 
         val request = builder.build()
-        val service = AuthorizationService(context, AppAuthConfiguration.DEFAULT)
-        return service.getAuthorizationRequestIntent(request, intentBuilder.build())
+        return authorizationService.getAuthorizationRequestIntent(request, intentBuilder.build())
 
     }
 

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/centralize/Launcher.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/centralize/Launcher.kt
@@ -23,7 +23,7 @@ import org.forgerock.android.auth.exception.BrowserAuthenticationException
  */
 internal class Launcher(
     val authorize: Pair<ActivityResultLauncher<Browser>, MutableStateFlow<Result<AuthorizationResponse, Throwable>?>>,
-    val endSession: Pair<ActivityResultLauncher<Pair<String, OAuth2Client>>, MutableStateFlow<Result<EndSessionResponse, Throwable>?>>,
+    val endSession: Pair<ActivityResultLauncher<EndSessionInput>, MutableStateFlow<Result<EndSessionResponse, Throwable>?>>,
 ) {
     /**
      * Starts the authorization process.
@@ -52,7 +52,7 @@ internal class Launcher(
      * @param pending A boolean indicating whether the session end process is pending.
      */
     suspend fun endSession(
-        request: Pair<String, OAuth2Client>,
+        request: EndSessionInput,
         pending: Boolean = false,
     ): EndSessionResponse {
         if (!pending) {

--- a/samples/app/src/main/java/com/example/app/LogoutViewModel.kt
+++ b/samples/app/src/main/java/com/example/app/LogoutViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2023 - 2024 ForgeRock. All rights reserved.
  *
  *  This software may be modified and distributed under the terms
  *  of the MIT license. See the LICENSE file for details.
@@ -8,12 +8,28 @@
 package com.example.app
 
 import androidx.lifecycle.ViewModel
+import net.openid.appauth.AppAuthConfiguration
+import net.openid.appauth.browser.BrowserDenyList
+import net.openid.appauth.browser.VersionedBrowserMatcher
 import org.forgerock.android.auth.FRUser
 
 class LogoutViewModel : ViewModel() {
 
+
+    /*
+    fun logout() {
+        val config = AppAuthConfiguration.Builder()
+            .setBrowserMatcher(BrowserDenyList(
+                VersionedBrowserMatcher.CHROME_CUSTOM_TAB,
+                VersionedBrowserMatcher.CHROME_BROWSER
+            ))
+            .build()
+
+        FRUser.getCurrentUser()?.logout(config)
+    }
+    */
+
     fun logout() {
         FRUser.getCurrentUser()?.logout()
     }
-
 }

--- a/samples/app/src/main/java/com/example/app/centralize/CentralizeLoginViewModel.kt
+++ b/samples/app/src/main/java/com/example/app/centralize/CentralizeLoginViewModel.kt
@@ -12,6 +12,8 @@ import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
+import net.openid.appauth.browser.BrowserDenyList
+import net.openid.appauth.browser.VersionedBrowserMatcher
 import org.forgerock.android.auth.FRListener
 import org.forgerock.android.auth.FRUser
 
@@ -23,22 +25,32 @@ class CentralizeLoginViewModel : ViewModel() {
     fun login(fragmentActivity: FragmentActivity) {
         FRUser.browser().appAuthConfigurer().customTabsIntent {
             it.setColorScheme(CustomTabsIntent.COLOR_SCHEME_DARK)
-
-        }.done()
+        }.appAuthConfiguration { appAuthConfiguration ->
+            /*
+            appAuthConfiguration.setBrowserMatcher(
+                BrowserDenyList(
+                    VersionedBrowserMatcher.CHROME_CUSTOM_TAB,
+                    VersionedBrowserMatcher.CHROME_BROWSER
+                )
+            )
+             */
+        }
+            .done()
             .login(fragmentActivity,
-            object : FRListener<FRUser> {
-                override fun onSuccess(result: FRUser) {
-                    state.update {
-                        it.copy(user = result, exception = null)
+                object : FRListener<FRUser> {
+                    override fun onSuccess(result: FRUser) {
+                        state.update {
+                            it.copy(user = result, exception = null)
+                        }
                     }
-                }
 
-                override fun onException(e: Exception) {
-                    state.update {
-                        it.copy(user = null, exception = e)
+                    override fun onException(e: Exception) {
+                        state.update {
+                            it.copy(user = null, exception = e)
+                        }
                     }
-                }
-            })
+                })
     }
+
 
 }

--- a/samples/app/src/main/java/com/example/app/env/EnvViewModel.kt
+++ b/samples/app/src/main/java/com/example/app/env/EnvViewModel.kt
@@ -26,7 +26,7 @@ class EnvViewModel : ViewModel() {
 
     val localhost = FROptionsBuilder.build {
         server {
-            url = "https://auth.pingone.ca/02fb4743-189a-4bc7-9d6c-a919edfe6447"
+            url = "https://auth.pingone.ca/02fb4743-189a-4bc7-9d6c-a919edfe6447/as"
             realm = "alpha"
             cookieName = "c1c805de4c9b333"
             timeout = 50
@@ -38,13 +38,6 @@ class EnvViewModel : ViewModel() {
             oauthScope = "openid profile email address phone"
             oauthThresholdSeconds = 0
             oauthSignOutRedirectUri = "org.forgerock.demo://oauth2redirect"
-        }
-        urlPath {
-            authorizeEndpoint = "/as/authorize"
-            tokenEndpoint = "/as/token"
-            endSessionEndpoint = "/as/signoff"
-            revokeEndpoint = "/as/revoke"
-            userinfoEndpoint = "/as/userinfo"
         }
         service {
             authServiceName = "protect"
@@ -131,7 +124,7 @@ class EnvViewModel : ViewModel() {
         server {
             url = "https://openam-sdks.forgeblocks.com/am"
             realm = "alpha"
-            cookieName = "iPlanetDirectoryPro"
+            cookieName = "5421aeddf91aa20"
             timeout = 50
         }
         oauth {


### PR DESCRIPTION
SDKS-3276 - Unable to signout user with browser when using different browser to signout. 

SDKS-3277 - The AppAuthConfiguration settings are being ignored during centralized login, causing unexpected behavior in the authentication flow.

# JIRA Ticket
[SDKS-3276](https://bugster.forgerock.org/jira/browse/SDKS-3276)
[SDKS-3277](https://bugster.forgerock.org/jira/browse/SDKS-3277)

# Description

Custom browser sample to SignIn with browser and Signout with browser

SignIn
```kotlin
        FRUser.browser().appAuthConfigurer().customTabsIntent {
            it.setColorScheme(CustomTabsIntent.COLOR_SCHEME_DARK)
        }.appAuthConfiguration { appAuthConfiguration ->
            appAuthConfiguration.setBrowserMatcher(
                BrowserDenyList(
                    VersionedBrowserMatcher.CHROME_CUSTOM_TAB,
                    VersionedBrowserMatcher.CHROME_BROWSER
                )
            )
        }
            .done()
            .login(fragmentActivity,
                object : FRListener<FRUser> {
                    override fun onSuccess(result: FRUser) {
                        ...
                    }

                    override fun onException(e: Exception) {
                        ...
                    }
                })
 
```

SignOut
```kotlin
 val config = AppAuthConfiguration.Builder()
            .setBrowserMatcher(BrowserDenyList(
                VersionedBrowserMatcher.CHROME_CUSTOM_TAB,
                VersionedBrowserMatcher.CHROME_BROWSER
            ))
            .build()

        FRUser.getCurrentUser()?.logout(config)
```
