### PR TITLE
SDKS-3279 Support file base configuration for forgerock_oauth_sign_out_redirect_uri

### DIFF
--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/ConfigHelper.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/ConfigHelper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 - 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2022 - 2024 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -156,6 +156,8 @@ internal class ConfigHelper {
                     oauthCacheSeconds =
                         context.resources.getInteger(R.integer.forgerock_oauth_cache)
                             .toLong()
+                    oauthSignOutRedirectUri =
+                        context.getString(R.string.forgerock_oauth_sign_out_redirect_uri)
                }
                 sslPinning {
                     pins = context.resources

--- a/forgerock-auth/src/main/res/values/strings.xml
+++ b/forgerock-auth/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2019 - 2022 ForgeRock. All rights reserved.
+  ~ Copyright (c) 2019 - 2024 ForgeRock. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.
@@ -15,6 +15,7 @@
     <string name="forgerock_oauth_url" translatable="false">place holder</string>
     <integer name="forgerock_oauth_threshold" translatable="false">30</integer> <!-- in second -->
     <integer name="forgerock_oauth_cache" translatable="false">0</integer> <!-- in second -->
+    <string name="forgerock_oauth_sign_out_redirect_uri" translatable="false">place holder</string>
 
     <!-- Server -->
     <string name="forgerock_url" translatable="false">place holder</string>

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/ConfigHelperTest.kt
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/ConfigHelperTest.kt
@@ -214,7 +214,7 @@ class ConfigHelperTest {
     @Test
     fun loadDefaultFROptionWithNull() {
        val defaultOption = ConfigHelper.load(context, null)
-       val expectedResult = "FROptions(server=Server(url=https://openam.example.com:8081/openam, realm=root, timeout=30, cookieName=iPlanetDirectoryPro, cookieCacheSeconds=0), oauth=OAuth(oauthClientId=andy_app, oauthRedirectUri=https://www.example.com:8080/callback, oauthSignOutRedirectUri=, oauthScope=openid email address, oauthThresholdSeconds=30, oauthCacheSeconds=0), service=Service(authServiceName=Test, registrationServiceName=Registration), urlPath=UrlPath(authenticateEndpoint=, revokeEndpoint=, sessionEndpoint=, tokenEndpoint=, userinfoEndpoint=, authorizeEndpoint=, endSessionEndpoint=), sslPinning=SSLPinning(buildSteps=[], pins=[9hNxmEFgLKGJXqgp61hyb8yIyiT9u0vgDZh4y8TmY/M=]), logger=Log(logLevel=null, customLogger=null))"
+       val expectedResult = "FROptions(server=Server(url=https://openam.example.com:8081/openam, realm=root, timeout=30, cookieName=iPlanetDirectoryPro, cookieCacheSeconds=0), oauth=OAuth(oauthClientId=andy_app, oauthRedirectUri=https://www.example.com:8080/callback, oauthSignOutRedirectUri=https://www.example.com:8080/signout, oauthScope=openid email address, oauthThresholdSeconds=30, oauthCacheSeconds=0), service=Service(authServiceName=Test, registrationServiceName=Registration), urlPath=UrlPath(authenticateEndpoint=, revokeEndpoint=, sessionEndpoint=, tokenEndpoint=, userinfoEndpoint=, authorizeEndpoint=, endSessionEndpoint=), sslPinning=SSLPinning(buildSteps=[], pins=[9hNxmEFgLKGJXqgp61hyb8yIyiT9u0vgDZh4y8TmY/M=]), logger=Log(logLevel=null, customLogger=null))"
         assertTrue(defaultOption.toString() == expectedResult)
     }
 

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/FRUserMockTest.java
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/FRUserMockTest.java
@@ -940,6 +940,7 @@ public class FRUserMockTest extends BaseTest {
         when(mockContext.getString(R.string.forgerock_endsession_endpoint)).thenReturn("dummy/endSession");
         when(mockContext.getString(R.string.forgerock_cookie_name)).thenReturn("testCookieName");
         when(mockContext.getString(R.string.forgerock_auth_service)).thenReturn("UsernamePassword");
+        when(mockContext.getString(R.string.forgerock_oauth_sign_out_redirect_uri)).thenReturn(context.getString(R.string.forgerock_oauth_sign_out_redirect_uri));
 
         enqueue("/authTreeMockTest_Authenticate_NameCallback.json", HttpURLConnection.HTTP_OK);
         enqueue("/authTreeMockTest_Authenticate_PasswordCallback.json", HttpURLConnection.HTTP_OK);

--- a/forgerock-auth/src/test/res/values/strings.xml
+++ b/forgerock-auth/src/test/res/values/strings.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2019 - 2022 ForgeRock. All rights reserved.
+  ~ Copyright (c) 2019 - 2024 ForgeRock. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.
@@ -11,6 +11,7 @@
     <!-- OAuth -->
     <string name="forgerock_oauth_client_id" translatable="false">andy_app</string>
     <string name="forgerock_oauth_redirect_uri" translatable="false">https://www.example.com:8080/callback</string>
+    <string name="forgerock_oauth_sign_out_redirect_uri" translatable="false">https://www.example.com:8080/signout</string>
     <string name="forgerock_oauth_scope" translatable="false">openid email address</string>
     <string name="forgerock_oauth_url" translatable="false">https://openam.example.com:8081/openam</string>
     <integer name="forgerock_oauth_threshold" translatable="false">30</integer> <!-- in second -->


### PR DESCRIPTION

# JIRA Ticket

[SDKS-3279](https://bugster.forgerock.org/jira/browse/SDKS-3279)

# Description

SDKS-3279 Support file base configuration for forgerock_oauth_sign_out_redirect_uri

Centralize logout for PingOne, make sure to override the oauth path
```
  <string name="forgerock_authorize_endpoint" translatable="false">https://auth.pingone.ca/$EnvId/as/authorize</string>
    <string name="forgerock_token_endpoint" translatable="false">https://auth.pingone.ca/$EnvId/as/token</string>
    <string name="forgerock_revoke_endpoint" translatable="false">https://auth.pingone.ca/$EnvId/as/revoke</string>
    <string name="forgerock_userinfo_endpoint" translatable="false">https://auth.pingone.ca/$EnvId/as/userinfo</string>
    <string name="forgerock_endsession_endpoint" translatable="false" >https://auth.pingone.ca/$EnvId/as/signoff</string>

```