### PR TITLE
SDKS-3284 Inconsistent behavior when forgerock_url is not provided.

### DIFF
--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/FRAuth.java
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/FRAuth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2019 - 2024 ForgeRock. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -30,6 +30,7 @@ import lombok.Singular;
  */
 public class FRAuth {
 
+    private static final String TAG = FRAuth.class.getSimpleName();
     private AuthService authService;
     private SessionManager sessionManager;
 
@@ -50,8 +51,12 @@ public class FRAuth {
             //Validate (AM URL, Realm, CookieName) is not Empty. If its empty will throw IllegalArgumentException.
             currentOptions.validateConfig();
             if (ConfigHelper.isConfigDifferentFromPersistedValue(context, currentOptions)) {
-               SessionManager sessionManager = ConfigHelper.getPersistedConfig(context, cachedOptions).getSessionManager();
-               sessionManager.close();
+                try {
+                    SessionManager sessionManager = ConfigHelper.getPersistedConfig(context, cachedOptions).getSessionManager();
+                    sessionManager.close();
+                } catch (Exception e) {
+                    Logger.warn(TAG, "Failed to close the session manager", e);
+                }
             }
             Config.getInstance().init(context, currentOptions);
             ConfigHelper.persist(context, currentOptions);

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/FROptions.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/FROptions.kt
@@ -46,7 +46,7 @@ data class FROptions(val server: Server,
     @Throws(IllegalArgumentException::class)
     @JvmName("validateConfig")
     internal fun validateConfig() {
-        require(server.url.isNotBlank()) { "AM URL cannot be blank" }
+        require(server.url.isNotBlank()) { "Server URL cannot be blank" }
         require(server.realm.isNotBlank()) { "Realm cannot be blank" }
         require(server.cookieName.isNotBlank()) { "cookieName cannot be blank" }
     }

--- a/forgerock-auth/src/main/res/values/strings.xml
+++ b/forgerock-auth/src/main/res/values/strings.xml
@@ -15,10 +15,10 @@
     <string name="forgerock_oauth_url" translatable="false">place holder</string>
     <integer name="forgerock_oauth_threshold" translatable="false">30</integer> <!-- in second -->
     <integer name="forgerock_oauth_cache" translatable="false">0</integer> <!-- in second -->
-    <string name="forgerock_oauth_sign_out_redirect_uri" translatable="false">place holder</string>
+    <string name="forgerock_oauth_sign_out_redirect_uri" translatable="false" />
 
     <!-- Server -->
-    <string name="forgerock_url" translatable="false">place holder</string>
+    <string name="forgerock_url" translatable="false" />
     <string name="forgerock_realm" translatable="false">root</string>
     <integer name="forgerock_timeout" translatable="false">30</integer>
     <integer name="forgerock_cookie_cache" translatable="false">0</integer> <!-- in second -->


### PR DESCRIPTION


# JIRA Ticket

[SDKS-3284](https://bugster.forgerock.org/jira/browse/SDKS-3284)

# Description

- Validate the server url before persist, for now, it does not validate the format, just make sure it is not empty.
- Ignore exception when failed to load the stored configuration.