### PR TITLE
SDKS-3283 Persisting the signOutRedirectUri into the shared preferences.

### DIFF
--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/Config.java
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/Config.java
@@ -54,19 +54,12 @@ public class Config {
     private CookieJar cookieJar;
     private String cookieName;
 
-    @Getter(value = AccessLevel.NONE)
     private String authenticateEndpoint;
-    @Getter(value = AccessLevel.NONE)
     private String authorizeEndpoint;
-    @Getter(value = AccessLevel.NONE)
     private String tokenEndpoint;
-    @Getter(value = AccessLevel.NONE)
     private String revokeEndpoint;
-    @Getter(value = AccessLevel.NONE)
     private String userinfoEndpoint;
-    @Getter(value = AccessLevel.NONE)
     private String sessionEndpoint;
-    @Getter(value = AccessLevel.NONE)
     private String endSessionEndpoint;
 
     //service

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/ConfigHelper.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/ConfigHelper.kt
@@ -26,6 +26,7 @@ internal class ConfigHelper {
         private const val sessionEndpoint = "session_endpoint"
         private const val scope = "scope"
         private const val redirectUri = "redirect_uri"
+        private const val signOutRedirectUri = "sign_out_redirect_uri"
 
         //Alias to store Previous Configure Host
         internal const val ORG_FORGEROCK_V_1_HOSTS = "org.forgerock.v1.HOSTS"
@@ -50,6 +51,7 @@ internal class ConfigHelper {
                 .putString(sessionEndpoint, frOptions.urlPath.sessionEndpoint)
                 .putString(scope, frOptions.oauth.oauthScope)
                 .putString(redirectUri, frOptions.oauth.oauthRedirectUri)
+                .putString(signOutRedirectUri, frOptions.oauth.oauthSignOutRedirectUri)
                 .apply()
         }
 
@@ -74,6 +76,7 @@ internal class ConfigHelper {
                     oauthClientId = sharedPreferences.getString(ConfigHelper.clientId, null) ?: context.getString(R.string.forgerock_oauth_client_id)
                     oauthScope = sharedPreferences.getString(ConfigHelper.scope, null) ?: context.getString(R.string.forgerock_oauth_scope)
                     oauthRedirectUri = sharedPreferences.getString(ConfigHelper.redirectUri, null) ?: context.getString(R.string.forgerock_oauth_redirect_uri)
+                    oauthSignOutRedirectUri = sharedPreferences.getString(ConfigHelper.signOutRedirectUri, null) ?: context.getString(R.string.forgerock_oauth_sign_out_redirect_uri)
                 }
                 urlPath {
                     endSessionEndpoint =
@@ -122,6 +125,11 @@ internal class ConfigHelper {
             }
             sharedPreferences.getString(redirectUri, null)?.apply {
                 if(frOptions.oauth.oauthRedirectUri != this) {
+                    return true
+                }
+            }
+            sharedPreferences.getString(signOutRedirectUri, null)?.apply {
+                if(frOptions.oauth.oauthSignOutRedirectUri != this) {
                     return true
                 }
             }

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/ConfigHelperTest.kt
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/ConfigHelperTest.kt
@@ -31,6 +31,7 @@ class ConfigHelperTest {
                 oauthClientId = "client_id"
                 oauthScope = "openid email address"
                 oauthRedirectUri = "https://redirecturi"
+                oauthSignOutRedirectUri = "https://signout"
             }
             urlPath {
                 revokeEndpoint = "https://revoke"
@@ -50,6 +51,7 @@ class ConfigHelperTest {
         assertTrue(sharedPreferences.getString("session_endpoint", null) == "https://logout")
         assertTrue(sharedPreferences.getString("scope", null) == "openid email address")
         assertTrue(sharedPreferences.getString("redirect_uri", null) == "https://redirecturi")
+        assertTrue(sharedPreferences.getString("sign_out_redirect_uri", null) == "https://signout")
     }
 
     @Test
@@ -64,6 +66,7 @@ class ConfigHelperTest {
                 oauthClientId = "client_id"
                 oauthScope = "scope"
                 oauthRedirectUri = "redirecturi"
+                oauthSignOutRedirectUri = "https://signout"
             }
             urlPath {
                 revokeEndpoint = "https://revoke"
@@ -81,6 +84,7 @@ class ConfigHelperTest {
                 oauthClientId = "client_id"
                 oauthScope = "scope"
                 oauthRedirectUri = "redirecturi"
+                oauthSignOutRedirectUri = "https://signout"
             }
             urlPath {
                 revokeEndpoint = "https://revoke"
@@ -97,6 +101,7 @@ class ConfigHelperTest {
                 oauthClientId = "client_id"
                 oauthScope = "scope"
                 oauthRedirectUri = "redirecturi"
+                oauthSignOutRedirectUri = "https://signout"
             }
             urlPath {
                 revokeEndpoint = "https://revoke"
@@ -113,6 +118,7 @@ class ConfigHelperTest {
                 oauthClientId = "client_id_1"
                 oauthScope = "scope"
                 oauthRedirectUri = "redirecturi"
+                oauthSignOutRedirectUri = "https://signout"
             }
             urlPath {
                 revokeEndpoint = "https://revoke"
@@ -129,6 +135,24 @@ class ConfigHelperTest {
                 oauthClientId = "client_id"
                 oauthScope = "scope"
                 oauthRedirectUri = "redirecturi_uri"
+                oauthSignOutRedirectUri = "https://signout"
+            }
+            urlPath {
+                revokeEndpoint = "https://revoke"
+                endSessionEndpoint = "https://endsession"
+            }
+        }
+        val signOutRedirectUriChanged = FROptionsBuilder.build {
+            server {
+                url = "https://dummy"
+                realm = "realm123"
+                cookieName = "cookieName"
+            }
+            oauth {
+                oauthClientId = "client_id"
+                oauthScope = "scope"
+                oauthRedirectUri = "redirecturi_uri"
+                oauthSignOutRedirectUri = "https://signout_changed"
             }
             urlPath {
                 revokeEndpoint = "https://revoke"
@@ -145,6 +169,7 @@ class ConfigHelperTest {
                 oauthClientId = "client_id"
                 oauthScope = "scope_test"
                 oauthRedirectUri = "redirecturi"
+                oauthSignOutRedirectUri = "https://signout"
             }
             urlPath {
                 revokeEndpoint = "https://revoke"
@@ -161,6 +186,7 @@ class ConfigHelperTest {
                 oauthClientId = "client_id"
                 oauthScope = "scope"
                 oauthRedirectUri = "redirecturi"
+                oauthSignOutRedirectUri = "https://signout"
             }
             urlPath {
                 revokeEndpoint = "https://revoke"
@@ -173,6 +199,7 @@ class ConfigHelperTest {
         assertTrue(ConfigHelper.isConfigDifferentFromPersistedValue(context, clientChanged))
         assertTrue(ConfigHelper.isConfigDifferentFromPersistedValue(context, expectedURL))
         assertTrue(ConfigHelper.isConfigDifferentFromPersistedValue(context, redirectURIChanged))
+        assertTrue(ConfigHelper.isConfigDifferentFromPersistedValue(context, signOutRedirectUriChanged))
         assertTrue(ConfigHelper.isConfigDifferentFromPersistedValue(context, scopeChanged))
         assertFalse(ConfigHelper.isConfigDifferentFromPersistedValue(context, frOptions))
 
@@ -193,6 +220,7 @@ class ConfigHelperTest {
                 oauthClientId = "andy_app"
                 oauthScope = "openid email address"
                 oauthRedirectUri = "https://www.example.com:8080/callback"
+                oauthSignOutRedirectUri = "https://www.example.com:8080/signout"
             }
             urlPath {
                 revokeEndpoint = ""


### PR DESCRIPTION
# JIRA Ticket

[SDKS-3283](https://bugster.forgerock.org/jira/browse/SDKS-3283) Starting the SDK with different configuration does NOT end user's session 

# Description

- Updated the `ConfigHelper` class to store the `signOutRedirectUri` into the share preferences
- Added back the getters to the path config variables (`authenticateEndpoint`, `authorizeEndpoint`, `tokenEndpoint`, `revokeEndpoint`, `userinfoEndpoint`, `sessionEndpoint`, `endSessionEndpoint`) to align the behavior with iOS