### PR TITLE
SDKS-3426 When compare the SessionToken associated with the AccessToken, it should just compare the value but not the SSOToken Object.

### DIFF
--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/RetrieveAccessTokenInterceptor.java
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/RetrieveAccessTokenInterceptor.java
@@ -45,7 +45,7 @@ class RetrieveAccessTokenInterceptor implements Interceptor<SSOToken> {
                 }
             } else {
                 return accessToken.getSessionToken() != null &&
-                        accessToken.getSessionToken().equals(sessionToken);
+                        accessToken.getSessionToken().getValue().equals(sessionToken.getValue());
             }
         }, new FRListener<AccessToken>() {
             @Override


### PR DESCRIPTION


# JIRA Ticket

[SDKS-3426](https://bugster.forgerock.org/jira/browse/SDKS-3426)

# Description

SDKS-3426 When compare the SessionToken associated with the AccessToken, it should just compare the value but not the SSOToken Object.