### PR TITLE
SDKS-3433 Allow http/https as redirect scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Support PingOne Protect Marketplace Node [SDKS-3279]
 - Expose Realm, Success Url with SSOToken [SDKS-3351]
 - Support Android 15 [SDKS-3098]
+- Allow http/https scheme for Centralize Login redirect [SDKS-3433]
 
 #### Fixed
 - Potential CustomTabManager ServiceConnection leak. [SDKS-3346]

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/FRUser.java
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/FRUser.java
@@ -348,6 +348,10 @@ public class FRUser {
 
         private void validateRedirectUri(Context context) throws InvalidRedirectUriException {
             Uri uri = Uri.parse(Config.getInstance().getRedirectUri());
+            if ("http".equals(uri.getScheme()) || "https".equals(uri.getScheme())) {
+                return;
+            }
+
             PackageManager pm = context.getPackageManager();
             List<ResolveInfo> resolveInfos = null;
             if (pm != null) {

--- a/samples/app/src/main/AndroidManifest.xml
+++ b/samples/app/src/main/AndroidManifest.xml
@@ -34,8 +34,12 @@
         android:usesCleartextTraffic="true"> <!-- usesCleartextTraffic set to true for testing purpose, DO NOT use this for production -->
 
         <!-- Support Facebook Login, make sure request for email scope App-> App Review -> Request for Permission -->
-        <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_app_id"/>
-        <meta-data android:name="com.facebook.sdk.ClientToken" android:value="@string/facebook_client_token"/>
+        <meta-data
+            android:name="com.facebook.sdk.ApplicationId"
+            android:value="@string/facebook_app_id" />
+        <meta-data
+            android:name="com.facebook.sdk.ClientToken"
+            android:value="@string/facebook_client_token" />
 
         <activity
             android:name=".MainActivity"
@@ -47,6 +51,7 @@
             </intent-filter>
         </activity>
 
+        <!-- Using Custom scheme
         <activity android:name="net.openid.appauth.RedirectUriReceiverActivity"
             android:exported="true"
             tools:node="replace">
@@ -56,6 +61,24 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data
                     android:scheme="org.forgerock.demo" />
+            </intent-filter>
+        </activity>
+        -->
+
+        <!-- Using https scheme -->
+        <activity
+            android:name="net.openid.appauth.RedirectUriReceiverActivity"
+            android:exported="true"
+            tools:node="replace">
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:host="example.com" />
+                <data android:path="/oauth2redirect" />
             </intent-filter>
         </activity>
 


### PR DESCRIPTION
# JIRA Ticket

[SDKS-3433](https://bugster.forgerock.org/jira/browse/SDKS-3433)

# Description

Allow http/https as redirect scheme

assetLinks.json for the sample App has been setup for idc.petrov.ca
https://idc.petrov.ca/.well-known/assetlinks.json

Update AndroidManifest.xml to use http/https scheme

Make sure it has autoVerify=true

```xml
 <activity
            android:name="net.openid.appauth.RedirectUriReceiverActivity"
            android:exported="true"
            tools:node="replace">
            <intent-filter android:autoVerify="true">
                <action android:name="android.intent.action.VIEW" />

                <category android:name="android.intent.category.DEFAULT" />
                <category android:name="android.intent.category.BROWSABLE" />

                <data android:scheme="https" />
                <data android:host="idc.petrov.ca" />
                <data android:path="/oauth2redirect" />
            </intent-filter>
        </activity>
``` 

More information about setting up the Applink
https://developer.android.com/studio/write/app-link-indexing
