### PR TITLE
SDKS-3697 Prevent duplicated notification on the SDK

### DIFF
--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/AuthenticatorManager.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/AuthenticatorManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2025 Ping Identity. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -245,6 +245,10 @@ class AuthenticatorManager {
             notification.setPushMechanism(mechanism);
         }
         return notification;
+    }
+
+    PushNotification getNotificationByMessageId(String messageId) {
+        return storageClient.getNotificationByMessageId(messageId);
     }
 
     void registerForRemoteNotifications(String newDeviceToken) throws AuthenticatorException {

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/DefaultStorageClient.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/DefaultStorageClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2025 Ping Identity. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -207,6 +207,17 @@ class DefaultStorageClient implements StorageClient {
     public PushNotification getNotification(String notificationId) {
         String json = notificationData.getString(notificationId, null);
         return PushNotification.deserialize(json);
+    }
+
+    @Override
+    public PushNotification getNotificationByMessageId(String messageId) {
+        List<PushNotification> allPushNotifications = getAllNotifications();
+        for(PushNotification pushNotification : allPushNotifications){
+            if(pushNotification.getMessageId().equals(messageId)){
+                return pushNotification;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/FRAClient.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/FRAClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2025 Ping Identity. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -281,6 +281,15 @@ public class FRAClient {
      */
     public PushNotification getNotification(@NonNull String notificationId) {
         return this.authenticatorManager.getNotification(notificationId);
+    }
+
+    /**
+     * Get the PushNotification object with its messageId.
+     * @param messageId The message unique ID
+     * @return The PushNotification object
+     */
+    public PushNotification getNotificationByMessageId(@NonNull String messageId) {
+        return this.authenticatorManager.getNotificationByMessageId(messageId);
     }
 
     /**

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/NotificationFactory.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/NotificationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2025 Ping Identity. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -83,6 +83,13 @@ class NotificationFactory {
         String customPayload;
         String numbersChallenge;
         String contextInfo;
+
+        // Check if notification with given messageId already exists
+        pushNotification = storageClient.getNotificationByMessageId(messageId);
+        if (pushNotification != null) {
+            Logger.debug(TAG, "PushNotification object with messageId %s already exists.", messageId);
+            return pushNotification;
+        }
 
         // Reconstruct JWT
         try {

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/StorageClient.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/StorageClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2025 Ping Identity. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -104,6 +104,13 @@ public interface StorageClient {
      * @return The PushNotification object.
      */
     PushNotification getNotification(String notificationId);
+
+    /**
+     * Get the PushNotification object with its messageId
+     * @param messageId The PushNotification messageId
+     * @return The PushNotification object.
+     */
+    PushNotification getNotificationByMessageId(String messageId);
 
     /**
      * Whether the storage system currently contains any data.

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/AuthenticatorManagerTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/AuthenticatorManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2025 Ping Identity. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -759,6 +759,30 @@ public class AuthenticatorManagerTest extends FRABaseTest {
         given(storageClient.getNotification(anyString())).willReturn(notification);
 
         PushNotification notificationFromStorage = authenticatorManager.getNotification(notification.getId());
+
+        assertNotNull(notificationFromStorage);
+        assertEquals(notification, notificationFromStorage);
+    }
+
+    @Test
+    public void testShouldGetStoredNotificationByMessageID() {
+        Account account = createAccount(ACCOUNT_NAME, ISSUER);
+        Mechanism push = createPushMechanism(ACCOUNT_NAME, ISSUER, MECHANISM_UID);
+        PushNotification notification = createPushNotification(MESSAGE_ID, push);
+
+        List<Mechanism> mechanismList= new ArrayList<>();
+        mechanismList.add(push);
+
+        List<PushNotification> notificationList = new ArrayList<>();
+        notificationList.add(createPushNotification(MESSAGE_ID, push));
+        notificationList.add(createPushNotification(OTHER_MESSAGE_ID, push));
+
+        given(storageClient.getAccount(any(String.class))).willReturn(account);
+        given(storageClient.getMechanismsForAccount(any(Account.class))).willReturn(mechanismList);
+        given(storageClient.getAllNotificationsForMechanism(any(Mechanism.class))).willReturn(notificationList);
+        given(storageClient.getNotificationByMessageId(anyString())).willReturn(notification);
+
+        PushNotification notificationFromStorage = authenticatorManager.getNotificationByMessageId(notification.getMessageId());
 
         assertNotNull(notificationFromStorage);
         assertEquals(notification, notificationFromStorage);

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/CustomStorageClient.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/CustomStorageClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2025 Ping Identity. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -91,6 +91,11 @@ public class CustomStorageClient implements StorageClient {
 
     @Override
     public PushNotification getNotification(String notificationId) {
+        return null;
+    }
+
+    @Override
+    public PushNotification getNotificationByMessageId(String messageId) {
         return null;
     }
 

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/DefaultStorageClientTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/DefaultStorageClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2025 Ping Identity. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -381,6 +381,39 @@ public class DefaultStorageClientTest extends FRABaseTest {
         Account accountFromStorage = defaultStorage.getAccount(account.getId());
         PushMechanism pushMechanismFromStorage = (PushMechanism) defaultStorage.getMechanismsForAccount(accountFromStorage).get(0);
         PushNotification pushNotificationFromStorage = defaultStorage.getNotification(pushNotification.getId());
+
+        assertNotNull(accountFromStorage);
+        assertNotNull(pushMechanismFromStorage);
+        assertNotNull(pushNotificationFromStorage);
+        assertEquals(pushNotificationFromStorage.getMechanismUID(), MECHANISM_UID);
+        assertEquals(pushNotificationFromStorage.getMessageId(), MESSAGE_ID);
+    }
+
+    @Test
+    public void testShouldGetNotificationByMessageId() {
+        DefaultStorageClient defaultStorage = new DefaultStorageClient(context);
+        defaultStorage.setAccountData(context.getApplicationContext()
+                .getSharedPreferences(TEST_SHARED_PREFERENCES_DATA_ACCOUNT, Context.MODE_PRIVATE));
+        defaultStorage.setMechanismData(context.getApplicationContext()
+                .getSharedPreferences(TEST_SHARED_PREFERENCES_DATA_MECHANISM, Context.MODE_PRIVATE));
+        defaultStorage.setNotificationData(context.getApplicationContext()
+                .getSharedPreferences(TEST_SHARED_PREFERENCES_DATA_NOTIFICATIONS, Context.MODE_PRIVATE));
+
+        Calendar timeAdded = Calendar.getInstance();
+
+        Account account = createAccountWithoutAdditionalData(ISSUER, ACCOUNT_NAME);
+        Mechanism mechanism = createPushMechanism(MECHANISM_UID, ISSUER, ACCOUNT_NAME, SECRET,
+                REGISTRATION_ENDPOINT, AUTHENTICATION_ENDPOINT);
+        PushNotification pushNotification = createPushNotification(MECHANISM_UID, MESSAGE_ID, CHALLENGE,
+                AMLB_COOKIE, timeAdded, TTL);
+
+        defaultStorage.setAccount(account);
+        defaultStorage.setMechanism(mechanism);
+        defaultStorage.setNotification(pushNotification);
+
+        Account accountFromStorage = defaultStorage.getAccount(account.getId());
+        PushMechanism pushMechanismFromStorage = (PushMechanism) defaultStorage.getMechanismsForAccount(accountFromStorage).get(0);
+        PushNotification pushNotificationFromStorage = defaultStorage.getNotificationByMessageId(pushNotification.getMessageId());
 
         assertNotNull(accountFromStorage);
         assertNotNull(pushMechanismFromStorage);

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/FRAClientTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/FRAClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2025 Ping Identity. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -719,6 +719,39 @@ public class FRAClientTest extends FRABaseTest {
         given(storageClient.getNotification(anyString())).willReturn(notification);
 
         PushNotification notificationFromStorage = fraClient.getNotification(notification.getId());
+
+        assertNotNull(notificationFromStorage);
+        assertEquals(notification, notificationFromStorage);
+    }
+
+    @Test
+    public void testShouldGetStoredNotificationByMessageID() throws Exception {
+        FRAClient fraClient = FRAClient.builder()
+                .withContext(context)
+                .withDeviceToken("s-o-m-e-t-o-k-e-n")
+                .withStorage(storageClient)
+                .start();
+
+        assertNotNull(fraClient);
+        assertNotNull(fraClient.getAuthenticatorManagerInstance());
+
+        Account account = createAccount(ACCOUNT_NAME, ISSUER);
+        Mechanism push = createPushMechanism(ACCOUNT_NAME, ISSUER, MECHANISM_UID);
+        PushNotification notification = createPushNotification(MESSAGE_ID, push);
+
+        List<Mechanism> mechanismList= new ArrayList<>();
+        mechanismList.add(push);
+
+        List<PushNotification> notificationList = new ArrayList<>();
+        notificationList.add(createPushNotification(MESSAGE_ID, push));
+        notificationList.add(createPushNotification(OTHER_MESSAGE_ID, push));
+
+        given(storageClient.getAccount(any(String.class))).willReturn(account);
+        given(storageClient.getMechanismsForAccount(any(Account.class))).willReturn(mechanismList);
+        given(storageClient.getAllNotificationsForMechanism(any(Mechanism.class))).willReturn(notificationList);
+        given(storageClient.getNotificationByMessageId(anyString())).willReturn(notification);
+
+        PushNotification notificationFromStorage = fraClient.getNotificationByMessageId(notification.getMessageId());
 
         assertNotNull(notificationFromStorage);
         assertEquals(notification, notificationFromStorage);

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/NotificationFactoryTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/NotificationFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2022 ForgeRock. All rights reserved.
+ * Copyright (c) 2020 - 2025 Ping Identity. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import java.util.Calendar;
 import java.util.Map;
 
 @RunWith(RobolectricTestRunner.class)
@@ -287,6 +288,22 @@ public class NotificationFactoryTest extends FRABaseTest {
             assertTrue(e instanceof InvalidNotificationException);
             assertTrue(e.getLocalizedMessage().equals("Unable to store Push Notification on the target stored system."));
         }
+    }
+
+    @Test
+    public void testShouldReturnExistingPushNotification() throws Exception {
+        RemoteMessage remoteMessage = generateMockRemoteMessage(MESSAGE_ID, CORRECT_SECRET, generateBaseMessage());
+        PushNotification storedPushNotification = createPushNotification(MECHANISM_UID, MESSAGE_ID, CHALLENGE,
+                AMLB_COOKIE, Calendar.getInstance(), TTL);
+        given(storageClient.getNotificationByMessageId(MESSAGE_ID)).willReturn(storedPushNotification);
+
+        PushNotification pushNotification = notificationFactory.handleMessage(remoteMessage);
+
+        assertNotNull(pushNotification);
+        assertEquals(MESSAGE_ID, pushNotification.getMessageId());
+        assertEquals(CHALLENGE, pushNotification.getChallenge());
+        assertEquals(MECHANISM_UID, pushNotification.getMechanismUID());
+        assertEquals(TTL, pushNotification.getTtl());
     }
 
 }


### PR DESCRIPTION
# JIRA Ticket

[SDKS-3697](https://pingidentity.atlassian.net/browse/SDKS-3697) Prevent duplicated notification on the SDK

# Description

The Android SDK does not verify whether a push notification with an identical message identifier has already been stored, delegating this responsibility to the application developer. This PR include the following changes:

- Added a new `getNotificationByMessageId` method to the StorageClient and FRAClient
- Updated the logic to check whether a payload was already persisted
- Update unit tests