### PR TITLE
[Fix] avoid to encode the realm when generating the authenticate url

### DIFF
--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/AuthServiceClient.java
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/AuthServiceClient.java
@@ -175,7 +175,7 @@ class AuthServiceClient {
         } else {
             builder.appendPath("json")
                     .appendPath("realms")
-                    .appendPath(serverConfig.getRealm())
+                    .appendEncodedPath(serverConfig.getRealm())
                     .appendPath("authenticate");
         }
         return builder;


### PR DESCRIPTION
This merge request addresses an issue where the authenticate endpoint URL was incorrectly generated, preventing the use of multi-level or nested realm paths (e.g., /my/pathTo/realm).

Previously, the Uri.Builder.appendPath() method was used for the realm segment. This method URL-encodes characters, converting forward slashes (/) into %2F. As a result, ForgeRock Access Management (AM) would interpret root/MyOrganizationLogin as a single literal realm name, instead of a path to a sub-realm, leading to authentication failures for nested realms.