### PR TITLE
SDKS-4190 Null check when casting context.getSystemService(Context.FINGERPRINT_SERVICE) to FingerprintManager

### DIFF
--- a/forgerock-core/src/main/java/org/forgerock/android/auth/biometric/BiometricAuth.kt
+++ b/forgerock-core/src/main/java/org/forgerock/android/auth/biometric/BiometricAuth.kt
@@ -179,7 +179,7 @@ class BiometricAuth @JvmOverloads constructor(
         biometricManager = BiometricManager.from(activity)
         keyguardManager = context.getSystemService(Context.KEYGUARD_SERVICE) as? KeyguardManager
         fingerprintManager =
-            context.getSystemService(Context.FINGERPRINT_SERVICE) as FingerprintManager
+            context.getSystemService(Context.FINGERPRINT_SERVICE) as? FingerprintManager
     }
 
     private fun initBiometricPrompt(authenticators: Int): BiometricPrompt {


### PR DESCRIPTION

# JIRA Ticket

[SDKS-4090](https://pingidentity.atlassian.net/browse/SDKS-4090)

# Description

SDKS-4190 Null check when casting context.getSystemService(Context.FINGERPRINT_SERVICE) to FingerprintManager

# Definition of Done Checklist:

- [ ] Coded to standards.
- [ ] Ensure backward compatibility.
- [ ] API reference docs is created or updated, if applicable.
- [ ] Unit tests are written or updated.
- [ ] Integration tests are written, if applicable.
