### PR TITLE
SDKS-4286 Update isExpired method in the PushNotification class to address out-of-sync scenarios

### DIFF
--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/PushNotification.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/PushNotification.java
@@ -244,8 +244,9 @@ public class PushNotification extends ModelObject<PushNotification> {
      * @return True if the notification has expired, false otherwise.
      */
     public final boolean isExpired() {
-        return timeExpired.getTimeInMillis() < Calendar.getInstance(TimeZone.getTimeZone("UTC"))
-                .getTimeInMillis();
+        // Calculate elapsed time since the notification was received (in seconds)
+        long elapsedTimeSeconds = (System.currentTimeMillis() - timeAdded.getTimeInMillis()) / 1000;
+        return elapsedTimeSeconds > ttl;
     }
 
     /**

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/PushNotificationTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/PushNotificationTest.java
@@ -738,9 +738,9 @@ public class PushNotificationTest extends FRABaseTest {
         // Now simulate a device time change by creating a new notification with a timeAdded much further in the past
         // This simulates what would happen if device time jumped forward by 1 hour
         Calendar timeAddedWithTimeChange = Calendar.getInstance();
-        timeAddedWithTimeChange.setTimeInMillis(currentTimeMillis - 90000); // Same 90 seconds ago
+        timeAddedWithTimeChange.setTimeInMillis(currentTimeMillis - 3690000); // 90 seconds + 1 hour ago (3600000 ms)
 
-        PushNotification pushNotificationWithCorrectElapsedTime = PushNotification.builder()
+        PushNotification pushNotificationWithTimeChange = PushNotification.builder()
                 .setMechanismUID(MECHANISM_UID)
                 .setMessageId(MESSAGE_ID)
                 .setChallenge(CHALLENGE)
@@ -749,10 +749,10 @@ public class PushNotificationTest extends FRABaseTest {
                 .setTtl(120) // 120 seconds TTL
                 .build();
 
-        // With our fixed implementation, this notification should also not be expired,
-        // since the actual elapsed time is the same (90 seconds)
-        assertFalse("Notification should not be expired even if device time is changed",
-                pushNotificationWithCorrectElapsedTime.isExpired());
+        // This notification should be expired since it was created 1 hour + 90 seconds ago
+        // which is well beyond the 120 second TTL
+        assertTrue("Notification should be expired when device time changes significantly",
+                pushNotificationWithTimeChange.isExpired());
 
         // Finally, test with a notification that should be expired (received 150 seconds ago)
         Calendar timeAddedExpired = Calendar.getInstance();


### PR DESCRIPTION
# JIRA Ticket

[SDKS-4286](https://pingidentity.atlassian.net/browse/SDKS-4286) [RFE] [FRA] - SDK sets isExpired flag out of sync with the server's attitude

# Description

Previously, the `isExpired` method in `PushNotication` was comparing the `timeExpired` value against the device's current time via `Calendar.getInstance(TimeZone.getTimeZone("UTC"))`. This makes the expiration check vulnerable to device clock manipulation. The logic was updated to make it more resilient by calculating the TTL based on the elapsed time since the notification was received, rather than directly comparing to the system time. This change also makes things consistent with how it already works on iOS.

# Definition of Done Checklist:

- [x] Coded to standards.
- [x] Ensure backward compatibility.
- [x] API reference docs is created or updated, if applicable.
- [x] Unit tests are written or updated.
- [ ] Integration tests are written, if applicable.
