### PR TITLE
SDKS-4392 - Improve error handling with fallback to current time while retrieving PushDeviceToken

### DIFF
--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/DefaultStorageClient.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/DefaultStorageClient.java
@@ -236,8 +236,28 @@ class DefaultStorageClient implements StorageClient {
 
     @Override
     public PushDeviceToken getPushDeviceToken() {
-        String json = deviceTokenData.getString(DEVICE_TOKEN_ID, null);
-        return PushDeviceToken.deserialize(json);
+        try {
+            String json = deviceTokenData.getString(DEVICE_TOKEN_ID, null);
+            if (json != null) {
+                PushDeviceToken token = PushDeviceToken.deserialize(json);
+                if (token == null) {
+                    // If deserialization failed due to corrupted data, clear it to allow recovery
+                    Logger.warn(TAG, "Corrupted PushDeviceToken data detected, clearing it to allow recovery");
+                    deviceTokenData.edit().remove(DEVICE_TOKEN_ID).commit();
+                }
+                return token;
+            }
+            return null;
+        } catch (Exception e) {
+            // Handle corrupted data that causes exceptions during decryption/parsing
+            Logger.warn(TAG, e, "Failed to retrieve PushDeviceToken due to corrupted data, clearing it to allow recovery");
+            try {
+                deviceTokenData.edit().remove(DEVICE_TOKEN_ID).commit();
+            } catch (Exception clearException) {
+                Logger.error(TAG, clearException, "Failed to clear corrupted PushDeviceToken data");
+            }
+            return null;
+        }
     }
 
     @Override

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/PushDeviceToken.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/PushDeviceToken.java
@@ -20,6 +20,8 @@ import java.util.Objects;
  */
 public class PushDeviceToken extends ModelObject<PushDeviceToken> {
 
+    private static final String TAG = PushDeviceToken.class.getSimpleName();
+
     private final String tokenId;
     private final Calendar timeAdded;
 
@@ -109,7 +111,7 @@ public class PushDeviceToken extends ModelObject<PushDeviceToken> {
         JSONObject jsonObject = new JSONObject();
         try {
             jsonObject.put("tokenId", getTokenId());
-            jsonObject.put("timeAdded", getTimeAdded());
+            jsonObject.put("timeAdded", getTimeAdded().getTimeInMillis());
         } catch (JSONException e) {
             throw new RuntimeException("Error parsing PushDeviceToken object to JSON string representation.", e);
         }
@@ -134,10 +136,25 @@ public class PushDeviceToken extends ModelObject<PushDeviceToken> {
 
         try {
             JSONObject jsonObject = new JSONObject(jsonString);
-            return new PushDeviceToken(
-                    jsonObject.getString("tokenId"),
-                    getDate(jsonObject.optLong("timeAdded")));
+            String tokenId = jsonObject.optString("tokenId", null);
+            if (tokenId.isEmpty()) {
+                Logger.warn(TAG, "Failed to deserialize PushDeviceToken: missing or empty tokenId");
+                return null;
+            }
+            
+            long timeAddedMillis = jsonObject.optLong("timeAdded", 0);
+            if (timeAddedMillis == 0) {
+                // For old format or corrupted data, use current time as fallback
+                Logger.warn(TAG, "Failed to parse timeAdded from PushDeviceToken, using current time as fallback");
+                timeAddedMillis = System.currentTimeMillis();
+            }
+            
+            return new PushDeviceToken(tokenId, getDate(timeAddedMillis));
         } catch (JSONException e) {
+            Logger.warn(TAG, e, "Failed to deserialize PushDeviceToken due to corrupted JSON data");
+            return null;
+        } catch (Exception e) {
+            Logger.warn(TAG, e, "Failed to deserialize PushDeviceToken due to unexpected error");
             return null;
         }
     }

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/DefaultStorageClientTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/DefaultStorageClientTest.java
@@ -8,6 +8,7 @@
 package org.forgerock.android.auth;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 
 import androidx.test.core.app.ApplicationProvider;
 
@@ -24,6 +25,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 public class DefaultStorageClientTest extends FRABaseTest {
@@ -609,6 +613,8 @@ public class DefaultStorageClientTest extends FRABaseTest {
                 .getSharedPreferences(TEST_SHARED_PREFERENCES_DATA_MECHANISM, Context.MODE_PRIVATE));
         defaultStorage.setNotificationData(context.getApplicationContext()
                 .getSharedPreferences(TEST_SHARED_PREFERENCES_DATA_NOTIFICATIONS, Context.MODE_PRIVATE));
+        defaultStorage.setDeviceTokenData(context.getApplicationContext()
+                .getSharedPreferences(TEST_SHARED_PREFERENCES_DATA_DEVICE_TOKEN, Context.MODE_PRIVATE));
 
         Calendar timeAdded = Calendar.getInstance();
 
@@ -617,16 +623,127 @@ public class DefaultStorageClientTest extends FRABaseTest {
                 REGISTRATION_ENDPOINT, AUTHENTICATION_ENDPOINT);
         PushNotification pushNotification = createPushNotification(MECHANISM_UID, MESSAGE_ID, CHALLENGE,
                 AMLB_COOKIE, timeAdded, TTL);
+        PushDeviceToken deviceToken = new PushDeviceToken("testToken123", timeAdded);
 
         defaultStorage.setAccount(account);
         defaultStorage.setMechanism(mechanism);
         defaultStorage.setNotification(pushNotification);
+        defaultStorage.setPushDeviceToken(deviceToken);
 
         assertFalse(defaultStorage.isEmpty());
 
         defaultStorage.removeAll();
 
         assertTrue(defaultStorage.isEmpty());
+    }
+
+    @Test
+    public void testStorePushDeviceToken() {
+        DefaultStorageClient defaultStorage = new DefaultStorageClient(context);
+        defaultStorage.setDeviceTokenData(context.getApplicationContext()
+                .getSharedPreferences(TEST_SHARED_PREFERENCES_DATA_DEVICE_TOKEN, Context.MODE_PRIVATE));
+        
+        // Create test token and its JSON representation
+        Calendar timeAdded = Calendar.getInstance();
+        timeAdded.setTimeInMillis(1704099600000L);
+        PushDeviceToken deviceToken = new PushDeviceToken("testToken123", timeAdded);
+        String expectedJson = deviceToken.toJson();
+
+        // Store the device token
+        boolean result = defaultStorage.setPushDeviceToken(deviceToken);
+        assertTrue(result);
+
+        // Retrieve and verify
+        PushDeviceToken retrieved = defaultStorage.getPushDeviceToken();
+        assertNotNull(retrieved);
+        assertEquals(expectedJson, retrieved.toJson());
+        assertEquals("testToken123", retrieved.getTokenId());
+        assertEquals(timeAdded.getTimeInMillis(), retrieved.getTimeAdded().getTimeInMillis());
+    }
+
+    @Test
+    public void testGetPushDeviceTokenWhenNoneExists() {
+        DefaultStorageClient defaultStorage = new DefaultStorageClient(context);
+        defaultStorage.setDeviceTokenData(context.getApplicationContext()
+                .getSharedPreferences(TEST_SHARED_PREFERENCES_DATA_DEVICE_TOKEN, Context.MODE_PRIVATE));
+
+        PushDeviceToken retrieved = defaultStorage.getPushDeviceToken();
+        assertNull(retrieved);
+    }
+
+    @Test
+    public void testPushDeviceTokenCorruptionRecovery() {
+        DefaultStorageClient defaultStorage = new DefaultStorageClient(context);
+        
+        // Create a mock SharedPreferences that will throw an exception when getString is called
+        SharedPreferences mockPrefs = mock(SharedPreferences.class);
+        SharedPreferences.Editor mockEditor = mock(SharedPreferences.Editor.class);
+        
+        // Configure mock to throw RuntimeException (simulating the corruption scenario)
+        when(mockPrefs.getString("deviceToken", null))
+            .thenThrow(new RuntimeException("org.json.JSONException: Unterminated string at character 804"));
+        
+        // Configure mock editor for cleanup
+        when(mockPrefs.edit()).thenReturn(mockEditor);
+        when(mockEditor.remove("deviceToken")).thenReturn(mockEditor);
+        when(mockEditor.commit()).thenReturn(true);
+        
+        // Inject the mock into the storage client
+        defaultStorage.setDeviceTokenData(mockPrefs);
+        
+        // This should not throw an exception and should return null
+        PushDeviceToken retrieved = defaultStorage.getPushDeviceToken();
+        assertNull(retrieved);
+        
+        // Verify that remove was called (cleanup happened)
+        verify(mockEditor).remove("deviceToken");
+        verify(mockEditor).commit();
+    }
+
+    @Test
+    public void testPushDeviceTokenBackwardCompatibility() {
+        DefaultStorageClient defaultStorage = new DefaultStorageClient(context);
+        
+        // Create a mock SharedPreferences that returns old format JSON (with Calendar.toString())
+        SharedPreferences mockPrefs = mock(SharedPreferences.class);
+        SharedPreferences.Editor mockEditor = mock(SharedPreferences.Editor.class);
+        
+        // Simulate old format JSON that would have caused the corruption
+        String oldFormatJson = "{\"tokenId\":\"oldToken123\",\"timeAdded\":\"java.util.GregorianCalendar[time=1704099600000,areFieldsSet=true,areAllFieldsSet=true,lenient=true,zone=java.util.SimpleTimeZone[id=UTC,offset=0,dstSavings=3600000,useDaylight=false,startYear=0,startMode=0,startMonth=0,startDay=0,startDayOfWeek=0,startTime=0,startTimeMode=0,endMode=0,endMonth=0,endDay=0,endDayOfWeek=0,endTime=0,endTimeMode=0],firstDayOfWeek=2,minimalDaysInFirstWeek=1,ERA=1,YEAR=2025,MONTH=8,WEEK_OF_YEAR=37,WEEK_OF_MONTH=2,DAY_OF_MONTH=14,DAY_OF_YEAR=257,DAY_OF_WEEK=1,DAY_OF_WEEK_IN_MONTH=2,AM_PM=1,HOUR=6,HOUR_OF_DAY=18,MINUTE=52,SECOND=21,MILLISECOND=637,ZONE_OFFSET=0,DST_OFFSET=0]\"}";
+        
+        when(mockPrefs.getString("deviceToken", null)).thenReturn(oldFormatJson);
+        when(mockPrefs.edit()).thenReturn(mockEditor);
+        when(mockEditor.remove("deviceToken")).thenReturn(mockEditor);
+        when(mockEditor.commit()).thenReturn(true);
+        
+        // Inject the mock into the storage client
+        defaultStorage.setDeviceTokenData(mockPrefs);
+        
+        // This should handle the old format gracefully
+        PushDeviceToken retrieved = defaultStorage.getPushDeviceToken();
+        assertNotNull(retrieved);
+        assertEquals("oldToken123", retrieved.getTokenId());
+        // Time should be set to current time as fallback since optLong("timeAdded") returns 0 for the string value
+        assertTrue(retrieved.getTimeAdded().getTimeInMillis() > 0);
+    }
+
+    @Test
+    public void testNewFormatPushDeviceTokenSerialization() {
+        // Test serialization format without involving DefaultStorageClient
+        Calendar timeAdded = Calendar.getInstance();
+        timeAdded.setTimeInMillis(1704099600000L); // Fixed timestamp for testing
+        PushDeviceToken deviceToken = new PushDeviceToken("newFormatToken", timeAdded);
+
+        // Verify new format serialization stores timestamp as long
+        String json = deviceToken.toJson();
+        assertTrue("New format should contain timeAdded as number", json.contains("\"timeAdded\":1704099600000"));
+        assertFalse("New format should not contain Calendar object string", json.contains("GregorianCalendar"));
+
+        // Test deserialization
+        PushDeviceToken deserialized = PushDeviceToken.deserialize(json);
+        assertNotNull(deserialized);
+        assertEquals("newFormatToken", deserialized.getTokenId());
+        assertEquals(1704099600000L, deserialized.getTimeAdded().getTimeInMillis());
     }
 
 }


### PR DESCRIPTION
# JIRA Ticket

[SDKS-4392](https://pingidentity.atlassian.net/browse/SDKS-4392) [Android] Improve error handling with fallback to current time while retrieving PushDeviceToken

# Description

An app may crash while running on specific Android devices due to JSON corruption in the encrypted storage system used by ForgeRock's authenticator module.

- The error occurs in `SecuredSharedPreferences.get()` method when trying to parse stored `PushDeviceToken` data
- The JSON string contained a `Calendar` object serialized using `Calendar.toString()`, which produces an extremely long string representation
- This long string seems to be vulnerable to corruption during the encryption/decryption process in `SecuredSharedPreferences` for some devices

In this PR we are improving the we are improving the error handling to add a corruption detection and recovery to prevent it from happen again

# Definition of Done Checklist:

- [x] Coded to standards.
- [x] Ensure backward compatibility.
- [ ] API reference docs is created or updated, if applicable.
- [x] Unit tests are written or updated.
- [ ] Integration tests are written, if applicable.
