### PR TITLE
SDKS-4409: Revert change from SDK version change from 28 back to 23

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Use the SDKs to leverage _[Intelligent Access](https://www.pingidentity.com/en/p
     * Ping Advanced Identity Cloud
     * PingAM 6.5.2+
 
-* Android API level 28+
-    * Android 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0
+* Android API level 23+
+    * Android 6.0 (Marshmallow), 7.0 (Nougat), 8.0 (Oreo), 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0
 
 <!------------------------------------------------------------------------------------------------------------------------------------>
 <!-- INSTALLATION - If you want to start quickly with minimal assistance. -->

--- a/buildSrc/src/main/kotlin/AndroidBuildGradlePlugin.kt
+++ b/buildSrc/src/main/kotlin/AndroidBuildGradlePlugin.kt
@@ -14,9 +14,9 @@ class AndroidBuildGradlePlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
         project.android().apply {
-            compileSdk = 36;
+            compileSdk = 36
             defaultConfig {
-                minSdk = 28
+                minSdk = 23
             }
             compileOptions {
                 sourceCompatibility = JavaVersion.VERSION_17

--- a/e2e/app/build.gradle.kts
+++ b/e2e/app/build.gradle.kts
@@ -16,7 +16,7 @@ android {
     compileSdk = 36
     defaultConfig {
         targetSdk = 36
-        minSdk = 28
+        minSdk = 23
     }
 
     buildTypes {

--- a/forgerock-auth-ui/build.gradle
+++ b/forgerock-auth-ui/build.gradle
@@ -17,7 +17,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdkVersion 28
+        minSdkVersion 23
         targetSdkVersion 36
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
# JIRA Ticket

[SDKS-4409](https://pingidentity.atlassian.net/browse/SDKS-4409?actionerId=712020%3A63898f22-4b5d-4737-b2d3-acf2ca9b9133&sourceType=assign)

# Description

Set minimum SDK version to 23 in build configuration files
Revert change from SDK version change from 28 back to 23.

# Definition of Done Checklist:

- [x] Coded to standards.
- [x] Ensure backward compatibility.
- [ ] API reference docs is created or updated, if applicable.
- [ ] Unit tests are written or updated.
- [ ] Integration tests are written, if applicable.
