### PR TITLE
SDKS-5096: Enhance WebAuthn registration by adding optional device name

### DIFF
--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/callback/WebAuthnRegistrationCallback.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/callback/WebAuthnRegistrationCallback.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2022 - 2026 Ping Identity Corporation. All rights reserved.
  *
  *  This software may be modified and distributed under the terms
  *  of the MIT license. See the LICENSE file for details.

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/callback/WebAuthnRegistrationCallback.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/callback/WebAuthnRegistrationCallback.kt
@@ -61,9 +61,9 @@ open class WebAuthnRegistrationCallback : MetadataCallback, WebAuthnCallback {
                 webAuthnRegistration.options = webAuthnRegistration.options.cloneWith(
                     ResidentKeyRequirement.valueOf(it))
             }
-            var result = webAuthnRegistration.register(context)
-            deviceName?.apply { result += "::$deviceName" }
-            setHiddenCallbackValue(node, result);
+
+            val result = webAuthnRegistration.register(context, deviceName)
+            setHiddenCallbackValue(node, result)
         } catch (e: Exception) {
             setErrorRethrow(node, e)
         }

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/webauthn/WebAuthnOutcome.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/webauthn/WebAuthnOutcome.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/webauthn/WebAuthnOutcome.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/webauthn/WebAuthnOutcome.kt
@@ -7,7 +7,9 @@
 
 package org.forgerock.android.auth.webauthn
 
+import android.annotation.SuppressLint
 import kotlinx.serialization.Serializable
 
+@SuppressLint("UnsafeOptInUsageError")
 @Serializable
 data class WebAuthnOutcome(val authenticatorAttachment: String , val legacyData: String)

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/webauthn/WebAuthnRegistration.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/webauthn/WebAuthnRegistration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2022 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -147,6 +147,15 @@ open class WebAuthnRegistration() : WebAuthn() {
         return getCredentials(excludeCredentials)
     }
 
+    /**
+     * Registers a new WebAuthn credential.
+     *
+     * @param context Application context used to launch the registration intent.
+     * @param deviceName Optional friendly name appended to the response so the server can label the credential.
+     *
+     * @return The registration outcome as a `::` delimited string, or a JSON-encoded
+     *   [WebAuthnOutcome] when the server supports JSON responses.
+     */
     suspend fun register(context: Context, deviceName: String? = null): String {
         val publicKeyCredential = getPublicKeyCredential(context)
         val response = publicKeyCredential.response as AuthenticatorAttestationResponse

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/webauthn/WebAuthnRegistration.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/webauthn/WebAuthnRegistration.kt
@@ -27,8 +27,6 @@ import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 import org.forgerock.android.auth.WebAuthnDataRepository
 import org.json.JSONArray
 import org.json.JSONException
@@ -149,7 +147,7 @@ open class WebAuthnRegistration() : WebAuthn() {
         return getCredentials(excludeCredentials)
     }
 
-    suspend fun register(context: Context): String {
+    suspend fun register(context: Context, deviceName: String? = null): String {
         val publicKeyCredential = getPublicKeyCredential(context)
         val response = publicKeyCredential.response as AuthenticatorAttestationResponse
         val sb = StringBuilder()
@@ -173,10 +171,11 @@ open class WebAuthnRegistration() : WebAuthn() {
                 persist(context, source)
             }
         }
+        deviceName?.let { sb.append("::$it") }
         return if (supportsJsonResponse) {
             val outcome = WebAuthnOutcome(publicKeyCredential.authenticatorAttachment ?: "platform",
                 sb.toString())
-            return Json.encodeToString(outcome)
+            Json.encodeToString(outcome)
         } else {
             sb.toString()
         }

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/callback/WebAuthnRegistrationCallbackTest.kt
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/callback/WebAuthnRegistrationCallbackTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2022 - 2026 Ping Identity Corporation. All rights reserved.
  *
  *  This software may be modified and distributed under the terms
  *  of the MIT license. See the LICENSE file for details.

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/callback/WebAuthnRegistrationCallbackTest.kt
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/callback/WebAuthnRegistrationCallbackTest.kt
@@ -22,6 +22,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.*
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.whenever
@@ -49,7 +50,7 @@ class WebAuthnRegistrationCallbackTest {
 
         val spCallback = spy(callback)
         doReturn(webAuthnRegistration).`when`(spCallback).getWebAuthnRegistration()
-        whenever(webAuthnRegistration.register(any())).thenReturn("SuccessResult")
+        whenever(webAuthnRegistration.register(any(), anyOrNull())).thenReturn("SuccessResult")
         spCallback.register(context, node = node)
         val hiddenValueCallback = node.getCallback(HiddenValueCallback::class.java)
         assertThat(hiddenValueCallback.contentAsJson.getJSONArray("input").getJSONObject(0)
@@ -89,7 +90,7 @@ class WebAuthnRegistrationCallbackTest {
 
         val spCallback = spy(callback)
         doReturn(webAuthnRegistration).`when`(spCallback).getWebAuthnRegistration()
-        whenever(webAuthnRegistration.register(any())).thenReturn("SuccessResult")
+        whenever(webAuthnRegistration.register(any(), anyOrNull())).thenReturn("SuccessResult")
         val future = FRListenerFuture<Void>()
         spCallback.register(context, node = node, listener = future)
         future.get()
@@ -106,7 +107,7 @@ class WebAuthnRegistrationCallbackTest {
         val callback = node.getCallback(WebAuthnRegistrationCallback::class.java)
         val spCallback = spy(callback)
         doReturn(webAuthnRegistration).`when`(spCallback).getWebAuthnRegistration()
-        whenever(webAuthnRegistration.register(any())).thenReturn("SuccessResult")
+        whenever(webAuthnRegistration.register(any(), anyOrNull())).thenReturn("SuccessResult::MyDeviceName")
         spCallback.register(context, "MyDeviceName", node)
         val hiddenValueCallback = node.getCallback(HiddenValueCallback::class.java)
         assertThat(hiddenValueCallback.contentAsJson.getJSONArray("input").getJSONObject(0)

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/webauthn/WebAuthnRegistrationTest.kt
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/webauthn/WebAuthnRegistrationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2022 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/webauthn/WebAuthnRegistrationTest.kt
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/webauthn/WebAuthnRegistrationTest.kt
@@ -144,9 +144,9 @@ class WebAuthnRegistrationTest : BaseTest() {
         }
         assertThat(webAuthnRegistration.supportsJsonResponse).isTrue
 
-        val result = webAuthnRegistration.register(context)
+        val result = webAuthnRegistration.register(context, deviceName = "testDevice")
 
-        assertThat(result).isEqualTo("{\"authenticatorAttachment\":\"platform\",\"legacyData\":\"clientDataJson::97,116,116,101,115,116,97,116,105,111,110,79,98,106,101,99,116::cmF3SWQ\"}")
+        assertThat(result).isEqualTo("{\"authenticatorAttachment\":\"platform\",\"legacyData\":\"clientDataJson::97,116,116,101,115,116,97,116,105,111,110,79,98,106,101,99,116::cmF3SWQ::testDevice\"}")
     }
 
 


### PR DESCRIPTION
# JIRA Ticket

[SDKS-5096](https://pingidentity.atlassian.net/browse/SDKS-5096)

# Description
This PR fixes the bug raised for omitting the device name supplied by the caller. The device name is now being added as part of the json response.

# Definition of Done Checklist:

- [x] Coded to standards.
- [ ] Ensure backward compatibility.
- [x] API reference docs is created or updated, if applicable.
- [x] Unit tests are written or updated.
- [ ] Integration tests are written, if applicable.
