### PR TITLE
SDKS-5120: Add authenticationValidityDuration support to device binding and signing

### DIFF
--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/callback/Binding.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/callback/Binding.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2022 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -9,6 +9,7 @@ package org.forgerock.android.auth.callback
 import android.os.OperationCanceledException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
+import org.forgerock.android.auth.DEFAULT_AUTHENTICATION_VALIDITY_DURATION
 import org.forgerock.android.auth.Logger
 import org.forgerock.android.auth.devicebind.DeviceAuthenticator
 import org.forgerock.android.auth.devicebind.DeviceBindingErrorStatus.Abort
@@ -21,6 +22,7 @@ import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
 private val TAG = Binding::class.java.simpleName
+
 
 /**
  * Device Binding interface to provide utility method for [DeviceBindingCallback] and [DeviceSigningVerifierCallback]
@@ -82,6 +84,16 @@ interface Binding {
     }
 
     fun setClientError(clientError: String?)
+
+    /**
+     * Validates that [authenticationValidityDuration] is greater than 0.
+     * The Android Keystore treats 0 and -1 as special values that disable the time-based window
+     * and require fresh user authentication on every single key use.
+     * @throws IllegalArgumentException if [value] is not greater than 0
+     */
+    fun validateAuthenticationValidityDuration(value: Int) {
+        require(value > 0) { "authenticationValidityDuration must be greater than 0" }
+    }
 
     /**
      * Default function to identify [DeviceAuthenticator]

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/callback/DeviceBindingCallback.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/callback/DeviceBindingCallback.kt
@@ -104,6 +104,12 @@ open class DeviceBindingCallback : AbstractCallback, Binding {
     lateinit var attestation: Attestation
         private set
 
+    /**
+     * The duration (in seconds) for which the generated key remains valid for user authentication.
+     * Passed to [CryptoKey] during key generation. Defaults to 5 seconds.
+     */
+    var authenticationValidityDuration: Int = 5
+
     init {
         //If attestation is not provided, default to NONE
         if (!::attestation.isInitialized) {
@@ -222,7 +228,7 @@ open class DeviceBindingCallback : AbstractCallback, Binding {
                                      .build().identifier,
                                  prompt: Prompt? = null) {
 
-        deviceAuthenticator.initialize(userId, prompt ?: Prompt(title, subtitle, description))
+        deviceAuthenticator.initialize(userId, authenticationValidityDuration, prompt ?: Prompt(title, subtitle, description))
 
         if (deviceAuthenticator.isSupported(context, attestation).not()) {
             handleException(DeviceBindingException(Unsupported()))

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/callback/DeviceBindingCallback.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/callback/DeviceBindingCallback.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2022 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -9,6 +9,7 @@ package org.forgerock.android.auth.callback
 import android.content.Context
 import android.util.Base64
 import androidx.annotation.Keep
+import org.forgerock.android.auth.DEFAULT_AUTHENTICATION_VALIDITY_DURATION
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -105,10 +106,24 @@ open class DeviceBindingCallback : AbstractCallback, Binding {
         private set
 
     /**
-     * The duration (in seconds) for which the generated key remains valid for user authentication.
-     * Passed to [CryptoKey] during key generation. Defaults to 5 seconds.
+     * The duration in seconds for which the generated key remains valid for user authentication
+     * without requiring a fresh biometric/credential prompt. Only affects biometric-backed key
+     * types ([DeviceBindingAuthenticationType.BIOMETRIC_ONLY] and
+     * [DeviceBindingAuthenticationType.BIOMETRIC_ALLOW_FALLBACK]); ignored for [DeviceBindingAuthenticationType.NONE]
+     * and [DeviceBindingAuthenticationType.APPLICATION_PIN].
+     *
+     * Must be greater than 0. The Android Keystore treats 0 and -1 as special values that disable
+     * the time-based window and require fresh user authentication on every single key use — which
+     * is very different from any positive duration. Setting this to 0 or -1 will throw
+     * [IllegalArgumentException].
+     *
+     * Defaults to [DEFAULT_AUTHENTICATION_VALIDITY_DURATION] seconds.
      */
-    var authenticationValidityDuration: Int = 5
+    var authenticationValidityDuration: Int = DEFAULT_AUTHENTICATION_VALIDITY_DURATION
+        set(value) {
+            validateAuthenticationValidityDuration(value)
+            field = value
+        }
 
     init {
         //If attestation is not provided, default to NONE

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/callback/DeviceSigningVerifierCallback.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/callback/DeviceSigningVerifierCallback.kt
@@ -115,6 +115,12 @@ open class DeviceSigningVerifierCallback : AbstractCallback, Binding {
     }
 
     /**
+     * The duration (in seconds) for which the generated key remains valid for user authentication.
+     * Passed to the underlying crypto key during key generation. Defaults to 5 seconds.
+     */
+    var authenticationValidityDuration: Int = 5
+
+    /**
      * Sign the challenge with bounded device keys.
      *
      * @param context  The Application Context
@@ -178,7 +184,7 @@ open class DeviceSigningVerifierCallback : AbstractCallback, Binding {
                                             customClaims: Map<String, Any> = emptyMap(),
                                             prompt: Prompt? = null) {
 
-        deviceAuthenticator.initialize(userKey.userId, prompt?: Prompt(title, subtitle, description))
+        deviceAuthenticator.initialize(userKey.userId, authenticationValidityDuration, prompt?: Prompt(title, subtitle, description))
 
         if (deviceAuthenticator.isSupported(context).not()) {
             handleException(DeviceBindingException(Unsupported()))

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/callback/DeviceSigningVerifierCallback.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/callback/DeviceSigningVerifierCallback.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2022 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -8,6 +8,7 @@ package org.forgerock.android.auth.callback
 
 import android.content.Context
 import androidx.annotation.Keep
+import org.forgerock.android.auth.DEFAULT_AUTHENTICATION_VALIDITY_DURATION
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -115,10 +116,24 @@ open class DeviceSigningVerifierCallback : AbstractCallback, Binding {
     }
 
     /**
-     * The duration (in seconds) for which the generated key remains valid for user authentication.
-     * Passed to the underlying crypto key during key generation. Defaults to 5 seconds.
+     * The duration in seconds for which the generated key remains valid for user authentication
+     * without requiring a fresh biometric/credential prompt. Only affects biometric-backed key
+     * types ([DeviceBindingAuthenticationType.BIOMETRIC_ONLY] and
+     * [DeviceBindingAuthenticationType.BIOMETRIC_ALLOW_FALLBACK]); ignored for [DeviceBindingAuthenticationType.NONE]
+     * and [DeviceBindingAuthenticationType.APPLICATION_PIN].
+     *
+     * Must be greater than 0. The Android Keystore treats 0 and -1 as special values that disable
+     * the time-based window and require fresh user authentication on every single key use — which
+     * is very different from any positive duration. Setting this to 0 or -1 will throw
+     * [IllegalArgumentException].
+     *
+     * Defaults to [DEFAULT_AUTHENTICATION_VALIDITY_DURATION] seconds.
      */
-    var authenticationValidityDuration: Int = 5
+    var authenticationValidityDuration: Int = DEFAULT_AUTHENTICATION_VALIDITY_DURATION
+        set(value) {
+            validateAuthenticationValidityDuration(value)
+            field = value
+        }
 
     /**
      * Sign the challenge with bounded device keys.

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/devicebind/DeviceBindAuthenticators.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/devicebind/DeviceBindAuthenticators.kt
@@ -72,7 +72,10 @@ interface DeviceAuthenticator {
      * @param kid Generated kid from the Preference
      * @param userId userId received from server
      * @param challenge challenge received from server
-     * @param customClaims A map of custom claims to be added to the jws payload
+     * @param expiration token expiration time
+     * @param attestation Attestation type to decide whether to include certificate chain in the JWS header
+     *
+     * @return the signed JWT as String
      */
     fun sign(context: Context,
              keyPair: KeyPair,
@@ -89,7 +92,7 @@ interface DeviceAuthenticator {
         if (attestation !is Attestation.None) {
             builder.x509CertChain(getCertificateChain(userId))
         }
-        val jwk = builder.build();
+        val jwk = builder.build()
         val signedJWT = SignedJWT(JWSHeader.Builder(parse(getAlgorithm()))
             .keyID(kid).jwk(jwk).build(),
             JWTClaimsSet.Builder().subject(userId)
@@ -210,7 +213,16 @@ interface DeviceAuthenticator {
 
 }
 
-fun DeviceAuthenticator.initialize(userId: String, prompt: Prompt): DeviceAuthenticator {
+/**
+ * Initialize the DeviceAuthenticator with userId, authentication validity duration and prompt
+ * @param userId The user ID for which the keys will be generated.
+ * @param authenticationValidityDuration The duration (in seconds) for which the generated key remains valid
+ * for user authentication. Passed to the underlying crypto key during key generation. Defaults to 5 seconds.
+ * @param prompt The Prompt to modify the title, subtitle, description
+ *
+ * @return The initialized DeviceAuthenticator instance.
+ */
+fun DeviceAuthenticator.initialize(userId: String, authenticationValidityDuration: Int,  prompt: Prompt): DeviceAuthenticator {
 
     //Inject objects
     if (this is BiometricAuthenticator) {
@@ -219,15 +231,23 @@ fun DeviceAuthenticator.initialize(userId: String, prompt: Prompt): DeviceAuthen
             prompt.description,
             deviceBindAuthenticationType = this.type()))
     }
-    initialize(userId)
+    initialize(userId, authenticationValidityDuration)
     this.prompt(prompt)
     return this
 }
 
-fun DeviceAuthenticator.initialize(userId: String): DeviceAuthenticator {
+/**
+ * Initialize the DeviceAuthenticator with userId and authentication validity duration
+ * @param userId The user ID for which the keys will be generated.
+ * @param authenticationValidityDuration The duration (in seconds) for which the generated key remains valid
+ * for user authentication. Passed to the underlying crypto key during key generation. Defaults to 5 seconds.
+ *
+ * @return The initialized DeviceAuthenticator instance.
+ */
+fun DeviceAuthenticator.initialize(userId: String, authenticationValidityDuration: Int = 5): DeviceAuthenticator {
     //Inject objects
     if (this is CryptoAware) {
-        this.setKey(CryptoKey(userId))
+        this.setKey(CryptoKey(userId, authenticationValidityDuration))
     }
     return this
 }

--- a/forgerock-auth/src/main/java/org/forgerock/android/auth/devicebind/DeviceBindAuthenticators.kt
+++ b/forgerock-auth/src/main/java/org/forgerock/android/auth/devicebind/DeviceBindAuthenticators.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2022 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -22,6 +22,7 @@ import com.nimbusds.jwt.SignedJWT
 import kotlinx.parcelize.Parcelize
 import org.forgerock.android.auth.CryptoKey
 import org.forgerock.android.auth.Logger
+import org.forgerock.android.auth.DEFAULT_AUTHENTICATION_VALIDITY_DURATION
 import org.forgerock.android.auth.callback.Attestation
 import org.forgerock.android.auth.callback.DeviceBindingAuthenticationType
 import java.security.PrivateKey
@@ -217,12 +218,12 @@ interface DeviceAuthenticator {
  * Initialize the DeviceAuthenticator with userId, authentication validity duration and prompt
  * @param userId The user ID for which the keys will be generated.
  * @param authenticationValidityDuration The duration (in seconds) for which the generated key remains valid
- * for user authentication. Passed to the underlying crypto key during key generation. Defaults to 5 seconds.
+ * for user authentication. Passed to the underlying crypto key during key generation.
  * @param prompt The Prompt to modify the title, subtitle, description
  *
  * @return The initialized DeviceAuthenticator instance.
  */
-fun DeviceAuthenticator.initialize(userId: String, authenticationValidityDuration: Int,  prompt: Prompt): DeviceAuthenticator {
+fun DeviceAuthenticator.initialize(userId: String, authenticationValidityDuration: Int, prompt: Prompt): DeviceAuthenticator {
 
     //Inject objects
     if (this is BiometricAuthenticator) {
@@ -244,7 +245,10 @@ fun DeviceAuthenticator.initialize(userId: String, authenticationValidityDuratio
  *
  * @return The initialized DeviceAuthenticator instance.
  */
-fun DeviceAuthenticator.initialize(userId: String, authenticationValidityDuration: Int = 5): DeviceAuthenticator {
+fun DeviceAuthenticator.initialize(
+    userId: String,
+    authenticationValidityDuration: Int = DEFAULT_AUTHENTICATION_VALIDITY_DURATION,
+): DeviceAuthenticator {
     //Inject objects
     if (this is CryptoAware) {
         this.setKey(CryptoKey(userId, authenticationValidityDuration))

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/callback/DeviceBindingCallbackTest.kt
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/callback/DeviceBindingCallbackTest.kt
@@ -319,6 +319,20 @@ class DeviceBindingCallbackTest {
         verify(encryptedPref, times(0)).persist(any())
     }
 
+    @Test(expected = IllegalArgumentException::class)
+    fun testAuthenticationValidityDurationRejectsZero() {
+        val rawContent =
+            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"NONE\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}"
+        DeviceBindingCallback(JSONObject(rawContent), 0).authenticationValidityDuration = 0
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testAuthenticationValidityDurationRejectsNegative() {
+        val rawContent =
+            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"NONE\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}"
+        DeviceBindingCallback(JSONObject(rawContent), 0).authenticationValidityDuration = -1
+    }
+
     @Test
     fun testAuthenticationValidityDurationDefaultValue() {
         val rawContent =
@@ -329,23 +343,27 @@ class DeviceBindingCallbackTest {
 
     @Test
     fun testAuthenticationValidityDurationCustomValuePassedToAuthenticator() = runBlocking {
+        // Uses BIOMETRIC_ONLY because NONE and APPLICATION_PIN ignore authenticationValidityDuration —
+        // CryptoKey.timeout is only consumed by biometric authenticators via
+        // setUserAuthenticationValidityDurationSeconds / setUserAuthenticationParameters.
         val rawContent =
-            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"NONE\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}"
+            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"BIOMETRIC_ONLY\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}"
         val encryptedPref = mock<DeviceBindingRepository>()
-        val deviceAuthenticator = mock<None>()
-        whenever(deviceAuthenticator.isSupported(any(), any())).thenReturn(true)
-        whenever(deviceAuthenticator.generateKeys(any(), any())).thenReturn(keyPair)
-        whenever(deviceAuthenticator.authenticate(any())).thenReturn(Success(keyPair.privateKey))
+        val biometricAuthenticator = mock<BiometricOnly>()
+        whenever(biometricAuthenticator.type()).thenReturn(DeviceBindingAuthenticationType.BIOMETRIC_ONLY)
+        whenever(biometricAuthenticator.isSupported(any(), any())).thenReturn(true)
+        whenever(biometricAuthenticator.generateKeys(any(), any())).thenReturn(keyPair)
+        whenever(biometricAuthenticator.authenticate(any())).thenReturn(Success(keyPair.privateKey))
 
         val testObject = DeviceBindingCallbackMockTest(rawContent)
         testObject.authenticationValidityDuration = 30
         testObject.testExecute(context,
-            deviceAuthenticator = deviceAuthenticator,
+            deviceAuthenticator = biometricAuthenticator,
             encryptedPreference = encryptedPref,
             "device_id")
 
         val captor: KArgumentCaptor<CryptoKey> = argumentCaptor()
-        verify(deviceAuthenticator).setKey(captor.capture())
+        verify(biometricAuthenticator).setKey(captor.capture())
         assertEquals(30, captor.firstValue.timeout)
     }
 

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/callback/DeviceBindingCallbackTest.kt
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/callback/DeviceBindingCallbackTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2022 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -67,7 +67,7 @@ class DeviceBindingCallbackTest {
     @Test
     fun testValuesAreSetProperly() {
         val rawContent =
-            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}";
+            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}"
         val obj = JSONObject(rawContent)
         val testObject = DeviceBindingCallback(obj, 0)
         assertEquals(rawContent, testObject.getContent())
@@ -76,7 +76,7 @@ class DeviceBindingCallbackTest {
     @Test
     fun testConfig() {
         val rawContent =
-            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}";
+            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}"
         val obj = JSONObject(rawContent)
         val testObject = DeviceBindingCallback(obj, 0)
         testObject.setDeviceName("jey")
@@ -85,14 +85,14 @@ class DeviceBindingCallbackTest {
         testObject.setClientError("Abort")
         val actualOutput = testObject.getContent()
         val expectedOut =
-            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"jws\"},{\"name\":\"IDToken1deviceName\",\"value\":\"jey\"},{\"name\":\"IDToken1deviceId\",\"value\":\"device_id\"},{\"name\":\"IDToken1clientError\",\"value\":\"Abort\"}]}";
+            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"jws\"},{\"name\":\"IDToken1deviceName\",\"value\":\"jey\"},{\"name\":\"IDToken1deviceId\",\"value\":\"device_id\"},{\"name\":\"IDToken1clientError\",\"value\":\"Abort\"}]}"
         assertEquals(expectedOut, actualOutput)
     }
 
     @Test
     fun testSuccessPathForNoneType() = runBlocking {
         val rawContent =
-            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"NONE\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}";
+            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"NONE\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}"
         val encryptedPref = mock<DeviceBindingRepository>()
         val deviceAuthenticator = mock<None>()
         whenever(deviceAuthenticator.isSupported(any(), any())).thenReturn(true)
@@ -115,7 +115,7 @@ class DeviceBindingCallbackTest {
     @Test
     fun testSuccessPathForBiometricType() = runBlocking {
         val rawContent =
-            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"BIOMETRIC_ONLY\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}";
+            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"BIOMETRIC_ONLY\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}"
         val deviceAuthenticator = mock<BiometricOnly>()
         whenever(deviceAuthenticator.type()).thenReturn(DeviceBindingAuthenticationType.BIOMETRIC_ONLY)
         whenever(deviceAuthenticator.isSupported(any(), any())).thenReturn(true)
@@ -150,7 +150,7 @@ class DeviceBindingCallbackTest {
     @Test
     fun testSuccessPathForBiometricAndCredentialType() = runBlocking {
         val rawContent =
-            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"BIOMETRIC_ALLOW_FALLBACK\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}";
+            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"BIOMETRIC_ALLOW_FALLBACK\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}"
         val scenario: ActivityScenario<DummyActivity> =
             ActivityScenario.launch(DummyActivity::class.java)
         scenario.onActivity {
@@ -182,7 +182,7 @@ class DeviceBindingCallbackTest {
     @Test
     fun testFailurePathForBiometricAbort(): Unit = runBlocking {
         val rawContent =
-            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}";
+            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}"
         val errorCode = -1
         val abort = Abort(code = errorCode)
         whenever(deviceAuthenticator.isSupported(any(), any())).thenReturn(true)
@@ -220,7 +220,7 @@ class DeviceBindingCallbackTest {
     @Test
     fun testFailurePathForBiometricTimeout(): Unit = runBlocking {
         val rawContent =
-            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}";
+            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}"
         whenever(deviceAuthenticator.isSupported(any(), any())).thenReturn(true)
         whenever(deviceAuthenticator.generateKeys(any(), any())).thenReturn(keyPair)
         whenever(deviceAuthenticator.authenticate(any())).thenReturn(Timeout())
@@ -253,7 +253,7 @@ class DeviceBindingCallbackTest {
     @Test
     fun testFailurePathForUnsupported(): Unit = runBlocking {
         val rawContent =
-            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}";
+            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}"
         whenever(deviceAuthenticator.isSupported(any(), any())).thenReturn(false)
         val testObject = DeviceBindingCallbackMockTest(rawContent)
         try {
@@ -270,7 +270,7 @@ class DeviceBindingCallbackTest {
 
         val actualOutput = testObject.getContent()
         val expectedOut =
-            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"Unsupported\"}]}";
+            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"Unsupported\"}]}"
         assertEquals(expectedOut, actualOutput)
 
         verify(encryptedPref, times(0)).delete(any())
@@ -290,7 +290,7 @@ class DeviceBindingCallbackTest {
     @Test
     fun testFailurePathForKeyGeneration(): Unit = runBlocking {
         val rawContent =
-            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}";
+            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}"
         whenever(deviceAuthenticator.isSupported(any(), any())).thenReturn(true)
         whenever(deviceAuthenticator.generateKeys(any(),
             any())).thenThrow(NullPointerException::class.java)
@@ -320,9 +320,39 @@ class DeviceBindingCallbackTest {
     }
 
     @Test
+    fun testAuthenticationValidityDurationDefaultValue() {
+        val rawContent =
+            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"NONE\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}"
+        val testObject = DeviceBindingCallback(JSONObject(rawContent), 0)
+        assertEquals(5, testObject.authenticationValidityDuration)
+    }
+
+    @Test
+    fun testAuthenticationValidityDurationCustomValuePassedToAuthenticator() = runBlocking {
+        val rawContent =
+            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"NONE\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}"
+        val encryptedPref = mock<DeviceBindingRepository>()
+        val deviceAuthenticator = mock<None>()
+        whenever(deviceAuthenticator.isSupported(any(), any())).thenReturn(true)
+        whenever(deviceAuthenticator.generateKeys(any(), any())).thenReturn(keyPair)
+        whenever(deviceAuthenticator.authenticate(any())).thenReturn(Success(keyPair.privateKey))
+
+        val testObject = DeviceBindingCallbackMockTest(rawContent)
+        testObject.authenticationValidityDuration = 30
+        testObject.testExecute(context,
+            deviceAuthenticator = deviceAuthenticator,
+            encryptedPreference = encryptedPref,
+            "device_id")
+
+        val captor: KArgumentCaptor<CryptoKey> = argumentCaptor()
+        verify(deviceAuthenticator).setKey(captor.capture())
+        assertEquals(30, captor.firstValue.timeout)
+    }
+
+    @Test
     fun testWithApplicationPinBinding(): Unit = runBlocking {
         val rawContent =
-            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}";
+            "{\"type\":\"DeviceBindingCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"id=demo,ou=user,dc=openam,dc=forgerock,dc=org\"},{\"name\":\"username\",\"value\":\"demo\"},{\"name\":\"authenticationType\",\"value\":\"APPLICATION_PIN\"},{\"name\":\"challenge\",\"value\":\"CS3+g40VkHXx+dN7rpnJKhrEAvwZaYgbaXoEcpO5twM=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":60},{\"name\":\"attestation\",\"value\":false}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1deviceName\",\"value\":\"\"},{\"name\":\"IDToken1deviceId\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}"
 
         val testObject = DeviceBindingCallbackMockTest(rawContent)
         val scenario: ActivityScenario<DummyActivity> =
@@ -338,9 +368,9 @@ class DeviceBindingCallbackTest {
     }
 
     fun getExpiration(): Date {
-        val date = Calendar.getInstance();
+        val date = Calendar.getInstance()
         date.add(Calendar.SECOND, 60)
-        return date.time;
+        return date.time
     }
 }
 
@@ -384,7 +414,7 @@ class DeviceBindingCallbackMockTest constructor(rawContent: String,
                     var byteArrayOutputStream = ByteArrayOutputStream(1024)
 
                     override fun getInputStream(context: Context): InputStream {
-                        return byteArrayOutputStream.toByteArray().inputStream();
+                        return byteArrayOutputStream.toByteArray().inputStream()
                     }
 
                     override fun getOutputStream(context: Context): OutputStream {

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/callback/DeviceSigningVerifierCallbackTest.kt
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/callback/DeviceSigningVerifierCallbackTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2022 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -13,6 +13,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import org.forgerock.android.auth.devicebind.DeviceAuthenticator
 import org.forgerock.android.auth.devicebind.DeviceBindFragment
+import org.forgerock.android.auth.devicebind.None
 import org.forgerock.android.auth.devicebind.DeviceBindingErrorStatus
 import org.forgerock.android.auth.devicebind.DeviceBindingException
 import org.forgerock.android.auth.devicebind.KeyPair
@@ -163,6 +164,37 @@ class DeviceSigningVerifierCallbackTest {
         val testObject =
             DeviceSigningVerifierCallbackMock(rawContent)
         testObject.executeAllKey(context, userKeyService) { deviceAuthenticator }
+    }
+
+    @Test
+    fun testAuthenticationValidityDurationDefaultValue() {
+        val rawContent =
+            "{\"type\":\"DeviceSigningVerifierCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"\"},{\"name\":\"challenge\",\"value\":\"zYwKaKnqS2YzvhXSK+sFjC7FKBoprArqz6LpJ8qe9+g=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":5}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}"
+        val testObject = DeviceSigningVerifierCallback(JSONObject(rawContent), 0)
+        assertEquals(5, testObject.authenticationValidityDuration)
+    }
+
+    @Test
+    fun testAuthenticationValidityDurationCustomValuePassedToAuthenticator() = runBlocking {
+        val rawContent =
+            "{\"type\":\"DeviceSigningVerifierCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"jey\"},{\"name\":\"challenge\",\"value\":\"zYwKaKnqS2YzvhXSK+sFjC7FKBoprArqz6LpJ8qe9+g=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":20}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}"
+        val userKey =
+            UserKey("id1", "jey", "jey", "kid", DeviceBindingAuthenticationType.NONE, System.currentTimeMillis())
+        val noneAuthenticator = mock<None>()
+        whenever(noneAuthenticator.isSupported(context)).thenReturn(true)
+        whenever(noneAuthenticator.validateCustomClaims(any())).thenReturn(true)
+        whenever(noneAuthenticator.authenticate(any())).thenReturn(Success(keyPair.privateKey))
+        whenever(noneAuthenticator.sign(
+            any<Context>(), any<UserKey>(), any<PrivateKey>(), any(), any<String>(), any<Date>(), any<Map<String, Any>>()
+        )).thenReturn("jws")
+
+        val testObject = DeviceSigningVerifierCallbackMock(rawContent)
+        testObject.authenticationValidityDuration = 30
+        testObject.executeAuthenticate(context, userKey, noneAuthenticator)
+
+        val captor: KArgumentCaptor<org.forgerock.android.auth.CryptoKey> = argumentCaptor()
+        verify(noneAuthenticator).setKey(captor.capture())
+        assertEquals(30, captor.firstValue.timeout)
     }
 
     fun getExpiration(): Date {

--- a/forgerock-auth/src/test/java/org/forgerock/android/auth/callback/DeviceSigningVerifierCallbackTest.kt
+++ b/forgerock-auth/src/test/java/org/forgerock/android/auth/callback/DeviceSigningVerifierCallbackTest.kt
@@ -8,9 +8,13 @@ package org.forgerock.android.auth.callback
 
 import android.content.Context
 import androidx.fragment.app.FragmentActivity
+import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.forgerock.android.auth.DummyActivity
+import org.forgerock.android.auth.InitProvider
 import kotlinx.coroutines.runBlocking
+import org.forgerock.android.auth.devicebind.BiometricOnly
 import org.forgerock.android.auth.devicebind.DeviceAuthenticator
 import org.forgerock.android.auth.devicebind.DeviceBindFragment
 import org.forgerock.android.auth.devicebind.None
@@ -166,6 +170,20 @@ class DeviceSigningVerifierCallbackTest {
         testObject.executeAllKey(context, userKeyService) { deviceAuthenticator }
     }
 
+    @Test(expected = IllegalArgumentException::class)
+    fun testAuthenticationValidityDurationRejectsZero() {
+        val rawContent =
+            "{\"type\":\"DeviceSigningVerifierCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"\"},{\"name\":\"challenge\",\"value\":\"zYwKaKnqS2YzvhXSK+sFjC7FKBoprArqz6LpJ8qe9+g=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":5}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}"
+        DeviceSigningVerifierCallback(JSONObject(rawContent), 0).authenticationValidityDuration = 0
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testAuthenticationValidityDurationRejectsNegative() {
+        val rawContent =
+            "{\"type\":\"DeviceSigningVerifierCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"\"},{\"name\":\"challenge\",\"value\":\"zYwKaKnqS2YzvhXSK+sFjC7FKBoprArqz6LpJ8qe9+g=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":5}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}"
+        DeviceSigningVerifierCallback(JSONObject(rawContent), 0).authenticationValidityDuration = -1
+    }
+
     @Test
     fun testAuthenticationValidityDurationDefaultValue() {
         val rawContent =
@@ -176,24 +194,31 @@ class DeviceSigningVerifierCallbackTest {
 
     @Test
     fun testAuthenticationValidityDurationCustomValuePassedToAuthenticator() = runBlocking {
+        // Uses BIOMETRIC_ONLY because NONE and APPLICATION_PIN ignore authenticationValidityDuration —
+        // CryptoKey.timeout is only consumed by biometric authenticators via
+        // setUserAuthenticationValidityDurationSeconds / setUserAuthenticationParameters.
         val rawContent =
             "{\"type\":\"DeviceSigningVerifierCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"jey\"},{\"name\":\"challenge\",\"value\":\"zYwKaKnqS2YzvhXSK+sFjC7FKBoprArqz6LpJ8qe9+g=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":20}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}"
         val userKey =
-            UserKey("id1", "jey", "jey", "kid", DeviceBindingAuthenticationType.NONE, System.currentTimeMillis())
-        val noneAuthenticator = mock<None>()
-        whenever(noneAuthenticator.isSupported(context)).thenReturn(true)
-        whenever(noneAuthenticator.validateCustomClaims(any())).thenReturn(true)
-        whenever(noneAuthenticator.authenticate(any())).thenReturn(Success(keyPair.privateKey))
-        whenever(noneAuthenticator.sign(
+            UserKey("id1", "jey", "jey", "kid", DeviceBindingAuthenticationType.BIOMETRIC_ONLY, System.currentTimeMillis())
+        val biometricAuthenticator = mock<BiometricOnly>()
+        whenever(biometricAuthenticator.type()).thenReturn(DeviceBindingAuthenticationType.BIOMETRIC_ONLY)
+        whenever(biometricAuthenticator.isSupported(context)).thenReturn(true)
+        whenever(biometricAuthenticator.validateCustomClaims(any())).thenReturn(true)
+        whenever(biometricAuthenticator.authenticate(any())).thenReturn(Success(keyPair.privateKey))
+        whenever(biometricAuthenticator.sign(
             any<Context>(), any<UserKey>(), any<PrivateKey>(), any(), any<String>(), any<Date>(), any<Map<String, Any>>()
         )).thenReturn("jws")
 
+        val scenario: ActivityScenario<DummyActivity> = ActivityScenario.launch(DummyActivity::class.java)
+        scenario.onActivity { InitProvider.setCurrentActivity(it) }
+
         val testObject = DeviceSigningVerifierCallbackMock(rawContent)
         testObject.authenticationValidityDuration = 30
-        testObject.executeAuthenticate(context, userKey, noneAuthenticator)
+        testObject.executeAuthenticate(context, userKey, biometricAuthenticator)
 
         val captor: KArgumentCaptor<org.forgerock.android.auth.CryptoKey> = argumentCaptor()
-        verify(noneAuthenticator).setKey(captor.capture())
+        verify(biometricAuthenticator).setKey(captor.capture())
         assertEquals(30, captor.firstValue.timeout)
     }
 
@@ -203,6 +228,7 @@ class DeviceSigningVerifierCallbackTest {
         return date.time;
     }
 
+    @Test
     fun testSignForForValidClaims() = runBlocking {
         val rawContent =
             "{\"type\":\"DeviceSigningVerifierCallback\",\"output\":[{\"name\":\"userId\",\"value\":\"jey\"},{\"name\":\"challenge\",\"value\":\"zYwKaKnqS2YzvhXSK+sFjC7FKBoprArqz6LpJ8qe9+g=\"},{\"name\":\"title\",\"value\":\"Authentication required\"},{\"name\":\"subtitle\",\"value\":\"Cryptography device binding\"},{\"name\":\"description\",\"value\":\"Please complete with biometric to proceed\"},{\"name\":\"timeout\",\"value\":20}],\"input\":[{\"name\":\"IDToken1jws\",\"value\":\"\"},{\"name\":\"IDToken1clientError\",\"value\":\"\"}]}"
@@ -224,6 +250,7 @@ class DeviceSigningVerifierCallbackTest {
     }
 
 
+    @Test
     fun testSignForForInvalidClaims() = runBlocking {
         val errorCode = -1
         val invalidCustomClaims = DeviceBindingErrorStatus.InvalidCustomClaims(code = errorCode)

--- a/forgerock-core/src/main/java/org/forgerock/android/auth/CryptoKey.kt
+++ b/forgerock-core/src/main/java/org/forgerock/android/auth/CryptoKey.kt
@@ -25,12 +25,11 @@ import java.security.spec.AlgorithmParameterSpec
 /**
  * Helper class to generate and sign the keys
  */
-class CryptoKey(private var keyId: String) {
+class CryptoKey(private var keyId: String, val timeout: Int = 5) {
 
     //For hashing the keyId
     private val hashingAlgorithm = "SHA-256"
     val keySize = 2048
-    val timeout = 5
     private val androidKeyStore = "AndroidKeyStore"
     private val encryptionBlockMode = KeyProperties.BLOCK_MODE_ECB
     private val encryptionPadding = KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1
@@ -65,7 +64,7 @@ class CryptoKey(private var keyId: String) {
         }
 
         keyPairGenerator.initialize(spec)
-        val keyPair = keyPairGenerator.generateKeyPair();
+        val keyPair = keyPairGenerator.generateKeyPair()
 
         return KeyPair(keyPair.public as RSAPublicKey, keyPair.private)
     }

--- a/forgerock-core/src/main/java/org/forgerock/android/auth/CryptoKey.kt
+++ b/forgerock-core/src/main/java/org/forgerock/android/auth/CryptoKey.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2022 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -22,10 +22,12 @@ import java.security.interfaces.RSAPublicKey
 import java.security.spec.AlgorithmParameterSpec
 
 
+const val DEFAULT_AUTHENTICATION_VALIDITY_DURATION = 5
+
 /**
  * Helper class to generate and sign the keys
  */
-class CryptoKey(private var keyId: String, val timeout: Int = 5) {
+class CryptoKey @JvmOverloads constructor(private var keyId: String, val timeout: Int = DEFAULT_AUTHENTICATION_VALIDITY_DURATION) {
 
     //For hashing the keyId
     private val hashingAlgorithm = "SHA-256"


### PR DESCRIPTION
# JIRA Ticket
[SDKS-5120](https://pingidentity.atlassian.net/browse/SDKS-5120)

# Description
- Adds authenticationValidityDuration field (default: 5 seconds) to DeviceBindingCallback and DeviceSigningVerifierCallback, giving callers control over how long the generated key remains valid for biometric/device
  authentication.
- Threads the value through to CryptoKey(userId, authenticationValidityDuration) via the DeviceAuthenticator.initialize extension, so the Android Keystore key is generated with the correct user-authentication validity window.
- Adds unit tests to DeviceBindingCallbackTest and DeviceSigningVerifierCallbackTest covering the default value and verifying the custom value propagates to CryptoKey.timeout.


# Definition of Done Checklist:

- [x] Coded to standards.
- [x] Ensure backward compatibility.
- [x] API reference docs is created or updated, if applicable.
- [x] Unit tests are written or updated.
- [ ] Integration tests are written, if applicable.
