### PR TITLE
[fix] SDKS-5114 Handle AM 400 for Push Number Challenge with distinct exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+#### Fixed
+- Fixed an issue where selecting the wrong number in a Push Number Challenge returned a generic error instead of a distinct exception [SDKS-5114]
+
 ## [4.8.5]
 
 #### Fixed

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/PushResponder.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/PushResponder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2020 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -23,6 +23,7 @@ import com.nimbusds.jwt.SignedJWT;
 
 import org.forgerock.android.auth.exception.ChallengeResponseException;
 import org.forgerock.android.auth.exception.PushMechanismException;
+import org.forgerock.android.auth.exception.PushNumberChallengeException;
 import org.forgerock.android.auth.util.RequestBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONException;
@@ -354,6 +355,10 @@ class PushResponder {
                         return;
                     }
                     listener.onSuccess(null);
+                } else if (response.code() == 400 && pushNotification.getPushType() == PushType.CHALLENGE) {
+                    // Number challenge failed — notification stays pending so the user can retry.
+                    listener.onException(new PushNumberChallengeException(
+                            "Number challenge failed: the selected number was incorrect."));
                 } else {
                     listener.onException(new PushMechanismException("Communication with " +
                             "server returned " + response.code() + " code."));

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/PushResponder.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/PushResponder.java
@@ -356,9 +356,18 @@ class PushResponder {
                     }
                     listener.onSuccess(null);
                 } else if (response.code() == 400 && pushNotification.getPushType() == PushType.CHALLENGE) {
-                    // Number challenge failed — notification stays pending so the user can retry.
-                    listener.onException(new PushNumberChallengeException(
-                            "Number challenge failed: the selected number was incorrect."));
+                    String challengeMessage = "Number challenge failed.";
+                    try {
+                        if (response.body() != null) {
+                            JSONObject json = new JSONObject(response.body().string());
+                            String amMessage = json.optString("message", null);
+                            if (amMessage != null && !amMessage.isEmpty()) {
+                                challengeMessage = amMessage;
+                            }
+                        }
+                    } catch (IOException | JSONException ignored) {}
+                    Logger.warn(TAG, "Push 400 response for CHALLENGE notification: %s", challengeMessage);
+                    listener.onException(new PushNumberChallengeException(challengeMessage));
                 } else {
                     listener.onException(new PushMechanismException("Communication with " +
                             "server returned " + response.code() + " code."));

--- a/forgerock-authenticator/src/main/java/org/forgerock/android/auth/exception/PushNumberChallengeException.java
+++ b/forgerock-authenticator/src/main/java/org/forgerock/android/auth/exception/PushNumberChallengeException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package org.forgerock.android.auth.exception;
+
+/**
+ * Represents an error that occurs during Push Number Challenge validation,
+ * such as when the user selects an incorrect number or the challenge cannot be processed.
+ */
+public class PushNumberChallengeException extends PushMechanismException {
+
+    /**
+     * Create a new exception containing a message.
+     * @param detailMessage The message cause of the exception.
+     */
+    public PushNumberChallengeException(String detailMessage) {
+        super(detailMessage);
+    }
+
+    /**
+     * Create a new exception containing a message and a cause.
+     * @param detailMessage The message cause of the exception.
+     * @param throwable The throwable cause of the exception.
+     */
+    public PushNumberChallengeException(String detailMessage, Throwable throwable) {
+        super(detailMessage, throwable);
+    }
+
+}

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/PushResponderTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/PushResponderTest.java
@@ -275,8 +275,35 @@ public class PushResponderTest extends FRABaseTest {
 
     @Test
     public void testReplyAuthenticationMessageNumberChallenge400() {
-        // AC (a): 400 on a CHALLENGE notification → PushNumberChallengeException with "incorrect"
-        //         message; notification stays pending=true, approved=false.
+        // AC (a): 400 on a CHALLENGE notification with AM JSON body → PushNumberChallengeException
+        //         surfaces AM's message; notification stays pending=true, approved=false.
+        server.enqueue(new MockResponse()
+                .setResponseCode(400)
+                .setBody("{\"code\":400,\"reason\":\"Bad Request\",\"message\":\"Number challenge predicate not met.\"}"));
+
+        PushNotification notification = null;
+        try {
+            notification = newChallengePushNotification();
+        } catch (Exception e) {
+            Assert.fail("Failed to build challenge notification: " + e.getMessage());
+        }
+
+        try {
+            PushResponder.getInstance(storageClient).authentication(notification, true, pushListenerFuture);
+            pushListenerFuture.get();
+            Assert.fail("Should throw PushNumberChallengeException");
+        } catch (Exception e) {
+            assertTrue(e.getCause() instanceof PushNumberChallengeException);
+            assertTrue(e.getLocalizedMessage().contains("Number challenge predicate not met."));
+            assertTrue(notification.isPending());
+            assertFalse(notification.isApproved());
+        }
+    }
+
+    @Test
+    public void testReplyAuthenticationMessageNumberChallenge400NoAmMessage() {
+        // AC (a2): 400 on a CHALLENGE notification with no body → fallback message used;
+        //          notification stays pending=true, approved=false.
         server.enqueue(new MockResponse().setResponseCode(400));
 
         PushNotification notification = null;
@@ -292,7 +319,7 @@ public class PushResponderTest extends FRABaseTest {
             Assert.fail("Should throw PushNumberChallengeException");
         } catch (Exception e) {
             assertTrue(e.getCause() instanceof PushNumberChallengeException);
-            assertTrue(e.getLocalizedMessage().contains("incorrect"));
+            assertTrue(e.getLocalizedMessage().contains("Number challenge failed."));
             assertTrue(notification.isPending());
             assertFalse(notification.isApproved());
         }

--- a/forgerock-authenticator/src/test/java/org/forgerock/android/auth/PushResponderTest.java
+++ b/forgerock-authenticator/src/test/java/org/forgerock/android/auth/PushResponderTest.java
@@ -11,6 +11,7 @@ import org.forgerock.android.auth.exception.ChallengeResponseException;
 import org.forgerock.android.auth.exception.InvalidNotificationException;
 import org.forgerock.android.auth.exception.MechanismCreationException;
 import org.forgerock.android.auth.exception.PushMechanismException;
+import org.forgerock.android.auth.exception.PushNumberChallengeException;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Assert;
@@ -36,6 +37,7 @@ import okhttp3.mockwebserver.SocketPolicy;
 
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -267,6 +269,86 @@ public class PushResponderTest extends FRABaseTest {
         assertEquals(hash, jwtSignature);
     }
 
+    // -----------------------------------------------------------------------
+    // Push Number Challenge (400) tests
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testReplyAuthenticationMessageNumberChallenge400() {
+        // AC (a): 400 on a CHALLENGE notification → PushNumberChallengeException with "incorrect"
+        //         message; notification stays pending=true, approved=false.
+        server.enqueue(new MockResponse().setResponseCode(400));
+
+        PushNotification notification = null;
+        try {
+            notification = newChallengePushNotification();
+        } catch (Exception e) {
+            Assert.fail("Failed to build challenge notification: " + e.getMessage());
+        }
+
+        try {
+            PushResponder.getInstance(storageClient).authentication(notification, true, pushListenerFuture);
+            pushListenerFuture.get();
+            Assert.fail("Should throw PushNumberChallengeException");
+        } catch (Exception e) {
+            assertTrue(e.getCause() instanceof PushNumberChallengeException);
+            assertTrue(e.getLocalizedMessage().contains("incorrect"));
+            assertTrue(notification.isPending());
+            assertFalse(notification.isApproved());
+        }
+    }
+
+    @Test
+    public void testReplyAuthenticationMessage400DefaultNotificationIsNotNumberChallengeException() throws Exception {
+        // AC (b): 400 on a DEFAULT notification → PushMechanismException (NOT PushNumberChallengeException)
+        //         with "400 code" in the message. Regression guard.
+        server.enqueue(new MockResponse().setResponseCode(400));
+
+        PushNotification notification = newPushNotification();
+
+        try {
+            PushResponder.getInstance(storageClient).authentication(notification, true, pushListenerFuture);
+            pushListenerFuture.get();
+            Assert.fail("Should throw PushMechanismException");
+        } catch (Exception e) {
+            assertTrue(e.getCause() instanceof PushMechanismException);
+            assertFalse(e.getCause() instanceof PushNumberChallengeException);
+            assertTrue(e.getLocalizedMessage().contains("400 code"));
+        }
+    }
+
+    @Test
+    public void testReplyAuthenticationMessage500ChallengeNotificationIsNotNumberChallengeException() throws Exception {
+        // AC (c): 500 on a CHALLENGE notification → PushMechanismException (NOT PushNumberChallengeException)
+        //         with "500 code" in the message. Regression guard.
+        server.enqueue(new MockResponse().setResponseCode(500));
+
+        PushNotification notification = newChallengePushNotification();
+
+        try {
+            PushResponder.getInstance(storageClient).authentication(notification, true, pushListenerFuture);
+            pushListenerFuture.get();
+            Assert.fail("Should throw PushMechanismException");
+        } catch (Exception e) {
+            assertTrue(e.getCause() instanceof PushMechanismException);
+            assertFalse(e.getCause() instanceof PushNumberChallengeException);
+            assertTrue(e.getLocalizedMessage().contains("500 code"));
+        }
+    }
+
+    @Test
+    public void testReplyAuthenticationMessageNumberChallenge200Success() throws Exception {
+        // AC (d): 200 on a CHALLENGE notification → onSuccess called; isPending=false, isApproved=true.
+        server.enqueue(new MockResponse());
+
+        PushNotification notification = newChallengePushNotification();
+        PushResponder.getInstance(storageClient).authentication(notification, true, pushListenerFuture);
+        pushListenerFuture.get();
+
+        assertFalse(notification.isPending());
+        assertTrue(notification.isApproved());
+    }
+
     private PushNotification newPushNotification() throws InvalidNotificationException, MechanismCreationException {
         Calendar time = Calendar.getInstance();
         PushNotification pushNotification = PushNotification.builder()
@@ -279,6 +361,26 @@ public class PushResponderTest extends FRABaseTest {
                 .setApproved(false)
                 .setPending(true)
                 .setTtl(TTL)
+                .build();
+
+        pushNotification.setPushMechanism(newPushMechanism());
+
+        return pushNotification;
+    }
+
+    private PushNotification newChallengePushNotification() throws InvalidNotificationException, MechanismCreationException {
+        Calendar time = Calendar.getInstance();
+        PushNotification pushNotification = PushNotification.builder()
+                .setMechanismUID(MECHANISM_UID)
+                .setMessageId(MESSAGE_ID)
+                .setChallenge(CHALLENGE)
+                .setAmlbCookie(AMLB_COOKIE)
+                .setTimeAdded(time)
+                .setTimeExpired(time)
+                .setApproved(false)
+                .setPending(true)
+                .setTtl(TTL)
+                .setPushType("challenge")
                 .build();
 
         pushNotification.setPushMechanism(newPushMechanism());


### PR DESCRIPTION
# JIRA Ticket

[SDKS-5114](https://pingidentity.atlassian.net/browse/SDKS-5114) "[Legacy][Android] forgerock-authenticator handle AM 400 for Push Number Challenge"

# Description

AM 8.1.0 added server-side validation for Push Number Challenge: selecting the wrong number now yields `400 Bad Request` on the authenticate endpoint instead of `200`. Previously `PushResponder.performAuthentication(...)` treated any non-200 as a generic `PushMechanismException("Communication with server returned <code> code.")`, so users got no semantic signal and the app could not distinguish a wrong-number rejection from a network failure. 

This change introduces a new `PushNumberChallengeException extends PushMechanismException` subtype and wires it into the `onResponse` callback: when the response code is `400` **and** the notification is `PushType.CHALLENGE`, throw the distinct exception and leave the notification `pending = true` / `approved = false` so the app can retry. All other code paths (200 success, non-CHALLENGE 400, 401/500/etc.) keep their current behavior exactly.

# Definition of Done Checklist:

- [x] Coded to standards.
- [ ] Ensure backward compatibility.
- [ ] API reference docs is created or updated, if applicable.
- [x] Unit tests are written or updated.
- [ ] Integration tests are written, if applicable.
